### PR TITLE
Add Sequence

### DIFF
--- a/Qsi.Debugger/Converters/ColumnBrushConverter.cs
+++ b/Qsi.Debugger/Converters/ColumnBrushConverter.cs
@@ -45,12 +45,8 @@ namespace Qsi.Debugger.Converters
             if (item.Column.IsAnonymous)
                 return _grey;
 
-            if (item.Column.Parent.Type == QsiTableType.Table ||
-                item.Column.Parent.Type == QsiTableType.View ||
-                item.Column.Parent.Type == QsiTableType.MaterializedView)
-            {
+            if (item.Column.Parent?.Type is QsiTableType.Table or QsiTableType.View or QsiTableType.MaterializedView)
                 return _red;
-            }
 
             return _grey;
         }

--- a/Qsi.Debugger/Converters/ColumnBrushConverter.cs
+++ b/Qsi.Debugger/Converters/ColumnBrushConverter.cs
@@ -45,7 +45,7 @@ namespace Qsi.Debugger.Converters
             if (item.Column.IsAnonymous)
                 return _grey;
 
-            if (item.Column.Parent?.Type is QsiTableType.Table or QsiTableType.View or QsiTableType.MaterializedView)
+            if (item.Column.Parent.Type is QsiTableType.Table or QsiTableType.View or QsiTableType.MaterializedView)
                 return _red;
 
             return _grey;

--- a/Qsi.Debugger/Converters/ColumnParentTypeConverter.cs
+++ b/Qsi.Debugger/Converters/ColumnParentTypeConverter.cs
@@ -13,6 +13,12 @@ namespace Qsi.Debugger.Converters
             if (value is not QsiColumnTreeItem item)
                 return value;
 
+            if (item.Column.ObjectReferences.Count > 0)
+            {
+                var objectReference = item.Column.ObjectReferences[0];
+                return $"{objectReference.Type}: {objectReference.Identifier}";
+            }
+
             var type = item.Column.Parent.Type.ToString().ToLower();
 
             if (item.Column.Parent.HasIdentifier)

--- a/Qsi.Debugger/Converters/ColumnParentTypeConverter.cs
+++ b/Qsi.Debugger/Converters/ColumnParentTypeConverter.cs
@@ -13,12 +13,6 @@ namespace Qsi.Debugger.Converters
             if (value is not QsiColumnTreeItem item)
                 return value;
 
-            if (item.Column.ObjectReferences.Count > 0)
-            {
-                var objectReference = item.Column.ObjectReferences[0];
-                return $"{objectReference.Type}: {objectReference.Identifier}";
-            }
-
             var type = item.Column.Parent.Type.ToString().ToLower();
 
             if (item.Column.Parent.HasIdentifier)

--- a/Qsi.Debugger/Converters/ColumnParentTypeConverter.cs
+++ b/Qsi.Debugger/Converters/ColumnParentTypeConverter.cs
@@ -13,11 +13,17 @@ namespace Qsi.Debugger.Converters
             if (value is not QsiColumnTreeItem item)
                 return value;
 
+            if (item.Column.ObjectReferences.Count > 0)
+            {
+                var objectReference = item.Column.ObjectReferences[0];
+                return $"{objectReference.Type}: {objectReference.Identifier}";
+            }
+
             var type = item.Column.Parent.Type.ToString().ToLower();
 
             if (item.Column.Parent.HasIdentifier)
                 return $"{type}: {item.Column.Parent.Identifier}";
-            
+
             return type;
         }
 

--- a/Qsi.Debugger/Vendor/Cql/CqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Cql/CqlRepositoryProvider.cs
@@ -1,4 +1,5 @@
 ﻿using Qsi.Data;
+using Qsi.Data.Object;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.Cql
@@ -55,6 +56,11 @@ namespace Qsi.Debugger.Vendor.Cql
         protected override QsiVariable LookupVariable(QsiQualifiedIdentifier identifier)
         {
             throw new System.NotImplementedException();
+        }
+
+        protected override QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type)
+        {
+            return null;
         }
     }
 }

--- a/Qsi.Debugger/Vendor/Hana/HanaRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Hana/HanaRepositoryProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Qsi.Data;
+using Qsi.Data.Object;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.Hana
@@ -77,6 +78,11 @@ namespace Qsi.Debugger.Vendor.Hana
         protected override QsiVariable LookupVariable(QsiQualifiedIdentifier identifier)
         {
             throw new NotImplementedException();
+        }
+
+        protected override QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type)
+        {
+            return null;
         }
     }
 }

--- a/Qsi.Debugger/Vendor/Impala/ImpalaRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Impala/ImpalaRepositoryProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Qsi.Data;
+using Qsi.Data.Object;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.Impala
@@ -80,6 +81,11 @@ namespace Qsi.Debugger.Vendor.Impala
         protected override QsiVariable LookupVariable(QsiQualifiedIdentifier identifier)
         {
             throw new NotImplementedException();
+        }
+
+        protected override QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type)
+        {
+            return null;
         }
     }
 }

--- a/Qsi.Debugger/Vendor/MySql/MySqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/MySql/MySqlRepositoryProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Qsi.Data;
 using System;
+using Qsi.Data.Object;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.MySql
@@ -87,6 +88,11 @@ namespace Qsi.Debugger.Vendor.MySql
                     };
             }
 
+            return null;
+        }
+
+        protected override QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type)
+        {
             return null;
         }
 

--- a/Qsi.Debugger/Vendor/Oracle/OracleRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Oracle/OracleRepositoryProvider.cs
@@ -98,7 +98,7 @@ namespace Qsi.Debugger.Vendor.Oracle
                 case QsiObjectType.Sequence:
                     switch (name)
                     {
-                        case "TEST_SEQENCE":
+                        case "TEST_SEQUENCE":
                             return new QsiSequenceObject(CreateIdentifier("xe", "SYSTEM", "TEST_SEQUENCE"));
                     }
 

--- a/Qsi.Debugger/Vendor/Oracle/OracleRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Oracle/OracleRepositoryProvider.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using Qsi.Data;
+using Qsi.Data.Object;
+using Qsi.Data.Object.Sequence;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.Oracle
@@ -85,6 +87,25 @@ namespace Qsi.Debugger.Vendor.Oracle
         protected override QsiVariable LookupVariable(QsiQualifiedIdentifier identifier)
         {
             throw new NotImplementedException();
+        }
+
+        protected override QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type)
+        {
+            var name = IdentifierUtility.Unescape(identifier[^1].Value);
+
+            switch (type)
+            {
+                case QsiObjectType.Sequence:
+                    switch (name)
+                    {
+                        case "TEST_SEQENCE":
+                            return new QsiSequenceObject(CreateIdentifier("xe", "SYSTEM", "TEST_SEQUENCE"));
+                    }
+
+                    break;
+            }
+
+            return null;
         }
     }
 }

--- a/Qsi.Debugger/Vendor/PhoenixSql/PhoenixSqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/PhoenixSql/PhoenixSqlRepositoryProvider.cs
@@ -1,4 +1,5 @@
 ﻿using Qsi.Data;
+using Qsi.Data.Object;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.PhoenixSql
@@ -55,6 +56,11 @@ namespace Qsi.Debugger.Vendor.PhoenixSql
         protected override QsiVariable LookupVariable(QsiQualifiedIdentifier identifier)
         {
             throw new System.NotImplementedException();
+        }
+
+        protected override QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type)
+        {
+            return null;
         }
 
         protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)

--- a/Qsi.Debugger/Vendor/PostgreSql/PostgreSqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/PostgreSql/PostgreSqlRepositoryProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Qsi.Data;
+using Qsi.Data.Object;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.PostgreSql
@@ -97,6 +98,11 @@ namespace Qsi.Debugger.Vendor.PostgreSql
         protected override QsiVariable LookupVariable(QsiQualifiedIdentifier identifier)
         {
             throw new NotImplementedException();
+        }
+
+        protected override QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type)
+        {
+            return null;
         }
 
         protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)

--- a/Qsi.Debugger/Vendor/PrimarSql/PrimarSqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/PrimarSql/PrimarSqlRepositoryProvider.cs
@@ -1,4 +1,5 @@
 ﻿using Qsi.Data;
+using Qsi.Data.Object;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.PrimarSql
@@ -53,6 +54,11 @@ namespace Qsi.Debugger.Vendor.PrimarSql
         protected override QsiVariable LookupVariable(QsiQualifiedIdentifier identifier)
         {
             throw new System.NotImplementedException();
+        }
+
+        protected override QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type)
+        {
+            return null;
         }
     }
 }

--- a/Qsi.Debugger/Vendor/SqlServer/SqlServerRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/SqlServer/SqlServerRepositoryProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Qsi.Data;
+using Qsi.Data.Object;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.SqlServer
@@ -75,6 +76,11 @@ namespace Qsi.Debugger.Vendor.SqlServer
         protected override QsiVariable LookupVariable(QsiQualifiedIdentifier identifier)
         {
             throw new NotImplementedException();
+        }
+
+        protected override QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type)
+        {
+            return null;
         }
     }
 }

--- a/Qsi.Debugger/Vendor/Trino/TrinoRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Trino/TrinoRepositoryProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Qsi.Data;
+using Qsi.Data.Object;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.Trino
@@ -64,6 +65,11 @@ namespace Qsi.Debugger.Vendor.Trino
         protected override QsiVariable LookupVariable(QsiQualifiedIdentifier identifier)
         {
             throw new NotImplementedException();
+        }
+
+        protected override QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type)
+        {
+            return null;
         }
     }
 }

--- a/Qsi.Oracle/Analyzers/OracleTableAnalyzer.cs
+++ b/Qsi.Oracle/Analyzers/OracleTableAnalyzer.cs
@@ -146,8 +146,14 @@ namespace Qsi.Oracle.Analyzers
                 if (OraclePseudoColumn.TryGetColumn(column.Name[0].Value, out var tableColumn))
                     return tableColumn;
 
-                // TODO: Work
-                // if (ResolveColumnFromObject(context, context))
+                throw;
+            }
+            catch (QsiException e) when (e.Error is QsiError.UnknownTableIn)
+            {
+                var objectColumn = ResolveColumnFromObject(context, column.Name);
+
+                if (objectColumn is not null)
+                    return objectColumn;
 
                 throw;
             }
@@ -165,11 +171,11 @@ namespace Qsi.Oracle.Analyzers
             if (qsiObject is null)
                 return null;
 
-            // TODO: Add Parent
             return new QsiTableColumn
             {
                 Name = qsiObject.Identifier[^1],
-                ObjectReferences = { qsiObject }
+                ObjectReferences = { qsiObject },
+                Parent = context.SourceTable
             };
         }
 

--- a/Qsi.Oracle/Analyzers/OracleTableAnalyzer.cs
+++ b/Qsi.Oracle/Analyzers/OracleTableAnalyzer.cs
@@ -149,6 +149,16 @@ namespace Qsi.Oracle.Analyzers
             }
         }
 
+        protected override QsiTableColumn ResolveColumnFromObject(TableCompileContext context, QsiQualifiedIdentifier identifier)
+        {
+            var lastName = identifier[^1];
+
+            if (lastName.Value != "CURRVAL" && lastName.Value != "NEXTVAL")
+                return null;
+
+            return base.ResolveColumnFromObject(context, identifier);
+        }
+
         protected override IEnumerable<QsiTableColumn> ResolveDerivedColumns(TableCompileContext context, IQsiDerivedColumnNode column)
         {
             if (column is OracleJsonColumnNode { NestedColumn: { } } node)

--- a/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
+++ b/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
@@ -748,21 +748,6 @@ namespace Qsi.Analyzers.Table
             return tables.SelectMany(t => includeInvisible ? t.Columns : t.VisibleColumns);
         }
 
-        protected virtual QsiTableColumn ResolveColumnFromObject(TableCompileContext context, QsiQualifiedIdentifier identifier)
-        {
-            // TODO: how get object another type
-            var qsiObject = LookupObject(context, new QsiQualifiedIdentifier(identifier[..^1]), QsiObjectType.Sequence);
-
-            if (qsiObject is null)
-                return null;
-
-            return new QsiTableColumn
-            {
-                Name = qsiObject.Identifier[^1],
-                ObjectReferences = { qsiObject }
-            };
-        }
-
         protected virtual QsiTableColumn ResolveColumnReference(TableCompileContext context, IQsiColumnReferenceNode column)
         {
             context.ThrowIfCancellationRequested();
@@ -775,14 +760,7 @@ namespace Qsi.Analyzers.Table
                 sources = LookupDataTableStructuresInExpression(context, identifier).ToArray();
 
                 if (!sources.Any())
-                {
-                    var objColumn = ResolveColumnFromObject(context, column.Name);
-
-                    if (objColumn is null)
-                        throw new QsiException(QsiError.UnknownTableIn, identifier, scopeFieldList);
-
-                    return objColumn;
-                }
+                    throw new QsiException(QsiError.UnknownTableIn, identifier, scopeFieldList);
             }
             else if (column.Name.Level == 0)
             {
@@ -1009,7 +987,7 @@ namespace Qsi.Analyzers.Table
         #endregion
 
         #region Table Lookup
-        private QsiQualifiedIdentifier ResolveQualifiedIdentifier(TableCompileContext context, QsiQualifiedIdentifier identifier)
+        protected QsiQualifiedIdentifier ResolveQualifiedIdentifier(TableCompileContext context, QsiQualifiedIdentifier identifier)
         {
             context.ThrowIfCancellationRequested();
 
@@ -1057,13 +1035,6 @@ namespace Qsi.Analyzers.Table
             tables.AddRange(context.SourceTables);
 
             return tables.Where(t => Match(context, t, identifier));
-        }
-        #endregion
-
-        #region Object Lookup
-        private QsiObject LookupObject(TableCompileContext context, QsiQualifiedIdentifier identifier, QsiObjectType type)
-        {
-            return context.Engine.RepositoryProvider.LookupObject(ResolveQualifiedIdentifier(context, identifier), type);
         }
         #endregion
 

--- a/Qsi/Data/Object/QsiObject.cs
+++ b/Qsi/Data/Object/QsiObject.cs
@@ -1,0 +1,14 @@
+﻿namespace Qsi.Data.Object
+{
+    public abstract class QsiObject
+    {
+        public abstract QsiObjectType Type { get; }
+
+        public QsiQualifiedIdentifier Identifier { get; }
+
+        protected QsiObject(QsiQualifiedIdentifier identifier)
+        {
+            Identifier = identifier;
+        }
+    }
+}

--- a/Qsi/Data/Object/QsiObjectType.cs
+++ b/Qsi/Data/Object/QsiObjectType.cs
@@ -1,0 +1,7 @@
+﻿namespace Qsi.Data.Object
+{
+    public enum QsiObjectType
+    {
+        Sequence
+    }
+}

--- a/Qsi/Data/Object/Sequence/QsiSequenceObject.cs
+++ b/Qsi/Data/Object/Sequence/QsiSequenceObject.cs
@@ -1,0 +1,11 @@
+﻿namespace Qsi.Data.Object.Sequence
+{
+    public class QsiSequenceObject : QsiObject
+    {
+        public override QsiObjectType Type => QsiObjectType.Sequence;
+
+        public QsiSequenceObject(QsiQualifiedIdentifier identifier) : base(identifier)
+        {
+        }
+    }
+}

--- a/Qsi/Data/Table/QsiTableColumn.cs
+++ b/Qsi/Data/Table/QsiTableColumn.cs
@@ -8,6 +8,7 @@ namespace Qsi.Data
 {
     public class QsiTableColumn
     {
+        // TODO: Revert setter access modifier to internal after refactoring QsiTableAnalyzer
         public QsiTableStructure Parent { get; set; }
 
         public QsiIdentifier Name { get; set; }

--- a/Qsi/Data/Table/QsiTableColumn.cs
+++ b/Qsi/Data/Table/QsiTableColumn.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Qsi.Data.Object;
 using Qsi.Tree;
 using Qsi.Utilities;
 
@@ -12,6 +13,8 @@ namespace Qsi.Data
         public QsiIdentifier Name { get; set; }
 
         public List<QsiTableColumn> References { get; } = new();
+
+        public List<QsiObject> ObjectReferences { get; } = new();
 
         public bool IsVisible { get; set; } = true;
 

--- a/Qsi/Data/Table/QsiTableColumn.cs
+++ b/Qsi/Data/Table/QsiTableColumn.cs
@@ -8,7 +8,7 @@ namespace Qsi.Data
 {
     public class QsiTableColumn
     {
-        public QsiTableStructure Parent { get; internal set; }
+        public QsiTableStructure Parent { get; set; }
 
         public QsiIdentifier Name { get; set; }
 

--- a/Qsi/Engines/Explain/ExplainRepositoryProvider.cs
+++ b/Qsi/Engines/Explain/ExplainRepositoryProvider.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Qsi.Analyzers;
 using Qsi.Analyzers.Table;
 using Qsi.Data;
+using Qsi.Data.Object;
 using Qsi.Services;
 
 namespace Qsi.Engines.Explain
@@ -39,6 +40,11 @@ namespace Qsi.Engines.Explain
             return _repositoryProvider.LookupVariable(identifier);
         }
 
+        public QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type)
+        {
+            return _repositoryProvider.LookupObject(identifier, type);
+        }
+
         public async Task<QsiDataTable> GetDataTable(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken)
         {
             IQsiAnalysisResult[] results = await _engine.Explain(script, cancellationToken);
@@ -51,7 +57,7 @@ namespace Qsi.Engines.Explain
 
             for (int i = 0; i < dataRow.Length; i++)
                 dataRow.Items[i] = QsiDataValue.Explain;
-            
+
             dataTable.Rows.Add(dataRow);
 
             return dataTable;

--- a/Qsi/Services/IQsiRepositoryProvider.cs
+++ b/Qsi/Services/IQsiRepositoryProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Qsi.Data;
+using Qsi.Data.Object;
 
 namespace Qsi.Services
 {
@@ -13,6 +14,8 @@ namespace Qsi.Services
         QsiScript LookupDefinition(QsiQualifiedIdentifier identifier, QsiTableType type);
 
         QsiVariable LookupVariable(QsiQualifiedIdentifier identifier);
+
+        QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type);
 
         Task<QsiDataTable> GetDataTable(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken);
     }

--- a/Qsi/Services/QsiRepositoryProviderBase.cs
+++ b/Qsi/Services/QsiRepositoryProviderBase.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Qsi.Data;
+using Qsi.Data.Object;
 
 namespace Qsi.Services
 {
@@ -13,6 +14,8 @@ namespace Qsi.Services
         protected abstract QsiScript LookupDefinition(QsiQualifiedIdentifier identifier, QsiTableType type);
 
         protected abstract QsiVariable LookupVariable(QsiQualifiedIdentifier identifier);
+
+        protected abstract QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type);
 
         protected abstract QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier);
 
@@ -50,6 +53,11 @@ namespace Qsi.Services
         QsiVariable IQsiRepositoryProvider.LookupVariable(QsiQualifiedIdentifier identifier)
         {
             return LookupVariable(identifier);
+        }
+
+        QsiObject IQsiRepositoryProvider.LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type)
+        {
+            return LookupObject(identifier, type);
         }
 
         QsiQualifiedIdentifier IQsiRepositoryProvider.ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)

--- a/Qsi/Utilities/QsiUtility.cs
+++ b/Qsi/Utilities/QsiUtility.cs
@@ -26,7 +26,26 @@ namespace Qsi.Utilities
 
         public static IEnumerable<QsiTableColumn> FlattenReferenceColumns(QsiTableColumn column)
         {
-            return FlattenCore(column, c => c.References, x => IsReferenceType(x.Parent.Type));
+            return FlattenCore(column, c => c.References, x => x.Parent is not null && IsReferenceType(x.Parent.Type));
+        }
+
+        public static IEnumerable<QsiObject> FlattenObjectReferences(QsiTableColumn column)
+        {
+            return FlattenObjectReferencesInternal(column, c => c.References, new HashSet<QsiTableColumn>());
+
+            static IEnumerable<QsiObject> FlattenObjectReferencesInternal(QsiTableColumn source, Func<QsiTableColumn, IEnumerable<QsiTableColumn>> selector, HashSet<QsiTableColumn> visited)
+            {
+                foreach (var objectReferences in source.ObjectReferences)
+                    yield return objectReferences;
+
+                foreach (var child in selector(source).Where(x => !visited.Contains(x)))
+                {
+                    visited.Add(child);
+
+                    foreach (var childReference in FlattenObjectReferencesInternal(child, selector, visited))
+                        yield return childReference;
+                }
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Qsi/Utilities/QsiUtility.cs
+++ b/Qsi/Utilities/QsiUtility.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Qsi.Data;
+using Qsi.Data.Object;
 
 namespace Qsi.Utilities
 {

--- a/Qsi/Utilities/QsiUtility.cs
+++ b/Qsi/Utilities/QsiUtility.cs
@@ -26,7 +26,7 @@ namespace Qsi.Utilities
 
         public static IEnumerable<QsiTableColumn> FlattenReferenceColumns(QsiTableColumn column)
         {
-            return FlattenCore(column, c => c.References, x => x.Parent is not null && IsReferenceType(x.Parent.Type));
+            return FlattenCore(column, c => c.References, x => IsReferenceType(x.Parent.Type));
         }
 
         public static IEnumerable<QsiObject> FlattenObjectReferences(QsiTableColumn column)


### PR DESCRIPTION
시퀀스 스펙이 추가 되었습니다.

다음과 같은 부분이 변경되었습니다.

- Qsi.Data 에 QsiObject와 하위 Sequence에 QsiSequenceObject가 추가되었습니다.
- RepositoryProvider에 추상 함수 GetObject가 추가되었습니다. 해당 함수는 Oracle에서만 구현합니다.
- OracleRepositoryProvider에서 ResolveColumnReference를 override 해서 column에서 테이블 추적에 실패했을 경우, Object (Sequence)로부터 정의를 추적하는 스펙이 추가되었습니다.
- QsiUtility에서 Column의 ObjectReference들을 모두 가져오는 FlattenObjectReferences 함수가 추가되었습니다.
- QsiTableAnalzyer에서 ResolveQualifiedIdentifier 함수가 private에서 protected로 변경되었습니다.

해당 스펙이 머지된 후 QSI 배포하고 엔진에서 QSI 버전을 올리기 전 select-sequence 관련 브랜치에서 QSI 버전을 올린다음 머지되어야 합니다.