### PR TITLE
Resolve SQLServer %%physloc%% parse error

### DIFF
--- a/Qsi.SqlServer/Analyzers/SqlServerTableAnalyzer.cs
+++ b/Qsi.SqlServer/Analyzers/SqlServerTableAnalyzer.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Qsi.Analyzers.Table;
+using Qsi.Analyzers.Table.Context;
+using Qsi.Data;
+using Qsi.Engines;
+using Qsi.SqlServer.Tree;
+using Qsi.Tree;
+
+namespace Qsi.SqlServer.Analyzers;
+
+public class SqlServerTableAnalyzer : QsiTableAnalyzer
+{
+    public SqlServerTableAnalyzer(QsiEngine engine) : base(engine)
+    {
+    }
+
+    protected override IEnumerable<QsiTableColumn> ResolveColumnsInExpression(TableCompileContext context, IQsiExpressionNode expression)
+    {
+        switch (expression)
+        {
+            case SqlServerPhyslocExpressionNode:
+                return Enumerable.Empty<QsiTableColumn>();
+        }
+
+        return base.ResolveColumnsInExpression(context, expression);
+    }
+}

--- a/Qsi.SqlServer/Diagnostics/SqlServerRawTree.cs
+++ b/Qsi.SqlServer/Diagnostics/SqlServerRawTree.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SqlServer.Management.SqlParser.SqlCodeDom;
 using Qsi.Diagnostics;
 
 namespace Qsi.SqlServer.Diagnostics
@@ -18,6 +20,30 @@ namespace Qsi.SqlServer.Diagnostics
         {
             DisplayName = displayName;
             _children = new List<IRawTree>();
+        }
+
+        public SqlServerRawTree(SqlCodeObject tree)
+        {
+            DisplayName = tree.GetType().Name;
+            SqlCodeObject[] childrens = tree.Children.ToArray();
+            int count = childrens.Length;
+
+            if (childrens.Length == 0)
+            {
+                Children = new IRawTree[] { new SqlServerRawTreeTerminalNode(tree.Sql) };
+            }
+            else
+            {
+                var trees = new IRawTree[count];
+
+                for (int i = 0; i < count; i++)
+                {
+                    var child = childrens[i];
+                    trees[i] = new SqlServerRawTree(child);
+                }
+
+                Children = trees;
+            }
         }
 
         internal void AddChild(IRawTree rawTree)

--- a/Qsi.SqlServer/Diagnostics/SqlServerRawTreeParser.cs
+++ b/Qsi.SqlServer/Diagnostics/SqlServerRawTreeParser.cs
@@ -1,21 +1,39 @@
-﻿using Qsi.Diagnostics;
+﻿using System;
+using System.Linq;
+using Qsi.Diagnostics;
 using Qsi.SqlServer.Common;
 using Qsi.SqlServer.Internal;
+using Microsoft.SqlServer.Management.SqlParser.Parser;
 
 namespace Qsi.SqlServer.Diagnostics
 {
     public sealed class SqlServerRawTreeParser : IRawTreeParser
     {
         private readonly TSqlParserInternal _parser;
-        
+
         public SqlServerRawTreeParser(TransactSqlVersion version)
         {
             _parser = new TSqlParserInternal(version, false);
         }
-        
+
         public IRawTree Parse(string input)
         {
-            return SqlServerRawTreeVisitor.CreateRawTree(_parser.Parse(input));
+            try
+            {
+                return SqlServerRawTreeVisitor.CreateRawTree(_parser.Parse(input));
+            }
+            catch (Exception)
+            {
+                if (input.Contains("physloc", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    var parseResult = Parser.Parse(input);
+
+                    if (!parseResult.Errors.Any())
+                        return new SqlServerRawTree(parseResult.Script);
+                }
+
+                throw;
+            }
         }
     }
 }

--- a/Qsi.SqlServer/Internal/AlternativeParserInternal.cs
+++ b/Qsi.SqlServer/Internal/AlternativeParserInternal.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Linq;
+using Microsoft.SqlServer.Management.SqlParser.Parser;
+using Microsoft.SqlServer.Management.SqlParser.SqlCodeDom;
+using Qsi.Parsing;
+using Qsi.SqlServer.Common;
+using ManagementTransactSqlVersion = Microsoft.SqlServer.Management.SqlParser.Common.TransactSqlVersion;
+
+namespace Qsi.SqlServer.Internal;
+
+internal sealed class AlternativeParserInternal
+{
+    private readonly ParseOptions _parserOptions;
+
+    public AlternativeParserInternal(TransactSqlVersion tsqlParserVersion)
+    {
+        _parserOptions = new ParseOptions
+        {
+            TransactSqlVersion = tsqlParserVersion switch
+            {
+                TransactSqlVersion.Version80 => ManagementTransactSqlVersion.Version105,
+                TransactSqlVersion.Version90 => ManagementTransactSqlVersion.Version105,
+                TransactSqlVersion.Version100 => ManagementTransactSqlVersion.Version105,
+                TransactSqlVersion.Version110 => ManagementTransactSqlVersion.Version110,
+                TransactSqlVersion.Version120 => ManagementTransactSqlVersion.Version120,
+                TransactSqlVersion.Version130 => ManagementTransactSqlVersion.Version130,
+                TransactSqlVersion.Version140 => ManagementTransactSqlVersion.Version140,
+                TransactSqlVersion.Version150 => ManagementTransactSqlVersion.Version150,
+                _ => ManagementTransactSqlVersion.Version160
+            }
+        };
+    }
+
+    public bool TryParse(string input, out SqlCodeObject result)
+    {
+        try
+        {
+            result = Parse(input);
+            return true;
+        }
+        catch (Exception)
+        {
+            result = null;
+            return false;
+        }
+    }
+
+    public SqlCodeObject Parse(string input)
+    {
+        var result = Parser.Parse(input, _parserOptions);
+
+        QsiSyntaxErrorException[] syntaxErrors = result.Errors
+            .Select(error => new QsiSyntaxErrorException(error.Start.LineNumber, error.Start.ColumnNumber, error.Message))
+            .ToArray();
+
+        switch (syntaxErrors.Length)
+        {
+            case 1:
+                throw syntaxErrors[0];
+
+            case > 1:
+                throw new AggregateException(syntaxErrors.Cast<Exception>());
+        }
+
+        return result.Script;
+    }
+}

--- a/Qsi.SqlServer/Qsi.SqlServer.csproj
+++ b/Qsi.SqlServer/Qsi.SqlServer.csproj
@@ -27,6 +27,10 @@
         </_PackageFiles>
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="160.22504.0" />
+    </ItemGroup>
+
     <Import Project="..\Qsi.Shared\Qsi.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/Qsi.SqlServer/SqlServerLanguageServiceBase.cs
+++ b/Qsi.SqlServer/SqlServerLanguageServiceBase.cs
@@ -48,7 +48,7 @@ namespace Qsi.SqlServer
         public override IEnumerable<QsiAnalyzerBase> CreateAnalyzers(QsiEngine engine)
         {
             yield return new SqlServerActionAnalyzer(engine);
-            yield return new QsiTableAnalyzer(engine);
+            yield return new SqlServerTableAnalyzer(engine);
             yield return new QsiDefinitionAnalyzer(engine);
         }
 

--- a/Qsi.SqlServer/Tree/SqlServerPhyslocExpressionNode.cs
+++ b/Qsi.SqlServer/Tree/SqlServerPhyslocExpressionNode.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Qsi.Tree;
+
+namespace Qsi.SqlServer.Tree;
+
+public class SqlServerPhyslocExpressionNode : QsiExpressionNode
+{
+    public override IEnumerable<IQsiTreeNode> Children => Enumerable.Empty<IQsiTreeNode>();
+}


### PR DESCRIPTION
`%%physloc%%` 컬럼이 쿼리에 포함되어 있는 경우 현재 Qsi.SqlServer에서 사용중인 `Microsoft.SqlServer.TransactSql.ScriptDom`의 파서로는 파싱이 되지 않는 문제를 해결했습니다.

추가된 로직은 다음과 같습니다.

1. 1차 파싱에 실패한 경우 쿼리에 `physloc` 텍스트가 포함되었는지 확인 (`%%physloc%%`으로 확인하지 못한 이유는 `%%    physloc %%` 와 같이 중간에 빈칸을 넣어도 정상 동작함을 확인해서 조금 루즈하게 검사했습니다.)

2. 만약 텍스트가 포함되었다면 `Microsoft.SqlServer.Management.SqlParser.Parser`로 한번 더 파싱합니다. 여기서 `%%physloc%%` 컬럼의 위치를 확인하고 기록합니다.

3. 해당 부분을 길이가 같은 빈 문자열 Expression으로 치환합니다.

4. ExpressionVisitor의 Literal 처리에서 기록해뒀던 `%%physloc%%` 컬럼의 위치와 같다면 Physloc 노드로 인식합니다.

메인 파서를 `Microsoft.SqlServer.Management.SqlParser.Parser`로 변경 할 수 없었던 이유는 해당 파서가 모든 노드에 대해서 정상적으로 노드를 내려주지 않고 `%%physloc%%`뿐 아니라 `IIF()`와 같은 노드들을 해당 노드의 위치만 알 수 있고 노드의 Property들을 제공 하지 않는 `SqlNullScalarExpression`로 반환하기에 메인 파서를 변경할 수 없었습니다.