### PR TITLE
Fix Oracle block semicolon

### DIFF
--- a/Qsi.Oracle/OracleScriptParser.cs
+++ b/Qsi.Oracle/OracleScriptParser.cs
@@ -23,8 +23,12 @@ namespace Qsi.Oracle
         private const string Begin = "BEGIN";
         private const string End = "END";
 
+        private const string Loop = "LOOP";
+        private const string Close = "CLOSE";
+
         private const string Case = "CASE";
         private const string If = "IF";
+        private const string Null = "NULL";
 
         private const string Exec = "EXEC";
         private const string Execute = "EXECUTE";
@@ -173,6 +177,16 @@ namespace Qsi.Oracle
                 }
                 else if (Exec.EqualsIgnoreCase(t.Current) ||
                          Execute.EqualsIgnoreCase(t.Current))
+                {
+                    block.ExpectedToken.Push(SemiColon);
+                }
+                else if (Loop.EqualsIgnoreCase(t.Current))
+                {
+                    block.ExpectedToken.Push(SemiColon);
+                    block.ExpectedToken.Push(Loop);
+                    block.ExpectedToken.Push(End);
+                }
+                else if (Null.EqualsIgnoreCase(t.Current))
                 {
                     block.ExpectedToken.Push(SemiColon);
                 }

--- a/Qsi.Tests/Qsi.Tests.csproj
+++ b/Qsi.Tests/Qsi.Tests.csproj
@@ -21,6 +21,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Qsi.MySql\Qsi.MySql.csproj" />
+      <ProjectReference Include="..\Qsi.Oracle\Qsi.Oracle.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Qsi.Tests/Vendor/Oracle/OracleScriptParserTest.Data.cs
+++ b/Qsi.Tests/Vendor/Oracle/OracleScriptParserTest.Data.cs
@@ -6,8 +6,11 @@ public partial class OracleScriptParserTest
 {
     private static readonly TestCaseData[] Parse_TestDatas =
     {
+        // SELECT
         new("SELECT 1 FROM DUAL;;") { ExpectedResult = "SELECT 1 FROM DUAL" },
-        new("CREATE TABLE a(id NUMBER);") { ExpectedResult = "CREATE TABLE a(id NUMBER);" },
+        // CREATE TABLE
+        new("CREATE TABLE a(id NUMBER);") { ExpectedResult = "CREATE TABLE a(id NUMBER)" },
+        // CREATE [OR REPLACE] PROCEDURE
         new(@"
 CREATE OR REPLACE PROCEDURE studentInsert(
     pName pl_student.name%TYPE,
@@ -39,6 +42,141 @@ BEGIN
     );
     COMMIT;
 END;"
+        },
+        // CREATE [OR REPLACE] FUNCTION
+        new(@"
+CREATE OR REPLACE FUNCTION get_complete_address(in_person_id IN NUMBER) 
+    RETURN VARCHAR2
+    IS person_details VARCHAR2(130);
+
+BEGIN 
+    SELECT 'Name-'||person.first_name||' '|| person.last_name||', City-'|| address.city ||', State-'||address.state||', Country-'||address.country||', ZIP Code-'||address.zip_code 
+    INTO person_details
+    FROM person_info person, person_address_details address
+    WHERE person.person_id = in_person_id 
+    AND address.person_id = person.person_id;
+
+    RETURN(person_details); 
+
+END get_complete_address;
+
+")
+        {
+            ExpectedResult = @"CREATE OR REPLACE FUNCTION get_complete_address(in_person_id IN NUMBER) 
+    RETURN VARCHAR2
+    IS person_details VARCHAR2(130);
+
+BEGIN 
+    SELECT 'Name-'||person.first_name||' '|| person.last_name||', City-'|| address.city ||', State-'||address.state||', Country-'||address.country||', ZIP Code-'||address.zip_code 
+    INTO person_details
+    FROM person_info person, person_address_details address
+    WHERE person.person_id = in_person_id 
+    AND address.person_id = person.person_id;
+
+    RETURN(person_details); 
+
+END get_complete_address;"
+        },
+        // CREATE [OR REPLACE] PACKAGE
+        new(@"
+CREATE OR REPLACE PACKAGE emp_mgmt AS 
+   FUNCTION hire (last_name VARCHAR2, job_id VARCHAR2, 
+      manager_id NUMBER, salary NUMBER, 
+      commission_pct NUMBER, department_id NUMBER) 
+      RETURN NUMBER; 
+   FUNCTION create_dept(department_id NUMBER, location_id NUMBER) 
+      RETURN NUMBER; 
+   PROCEDURE remove_emp(employee_id NUMBER); 
+   PROCEDURE remove_dept(department_id NUMBER); 
+   PROCEDURE increase_sal(employee_id NUMBER, salary_incr NUMBER); 
+   PROCEDURE increase_comm(employee_id NUMBER, comm_incr NUMBER); 
+   no_comm EXCEPTION; 
+   no_sal EXCEPTION; 
+END emp_mgmt;  ")
+        {
+            ExpectedResult = @"CREATE OR REPLACE PACKAGE emp_mgmt AS 
+   FUNCTION hire (last_name VARCHAR2, job_id VARCHAR2, 
+      manager_id NUMBER, salary NUMBER, 
+      commission_pct NUMBER, department_id NUMBER) 
+      RETURN NUMBER; 
+   FUNCTION create_dept(department_id NUMBER, location_id NUMBER) 
+      RETURN NUMBER; 
+   PROCEDURE remove_emp(employee_id NUMBER); 
+   PROCEDURE remove_dept(department_id NUMBER); 
+   PROCEDURE increase_sal(employee_id NUMBER, salary_incr NUMBER); 
+   PROCEDURE increase_comm(employee_id NUMBER, comm_incr NUMBER); 
+   no_comm EXCEPTION; 
+   no_sal EXCEPTION; 
+END emp_mgmt;"
+        },
+        // CREATE [OR REPLACE] TRIGGER
+        new(@"
+CREATE OR REPLACE TRIGGER customers_audit_trg
+    AFTER 
+    UPDATE OR DELETE 
+    ON customers
+    FOR EACH ROW    
+DECLARE
+   l_transaction VARCHAR2(10);
+BEGIN
+   -- determine the transaction type
+   l_transaction := CASE  
+         WHEN UPDATING THEN 'UPDATE'
+         WHEN DELETING THEN 'DELETE'
+   END;
+
+   -- insert a row into the audit table   
+   INSERT INTO audits (table_name, transaction_name, by_user, transaction_date)
+   VALUES('CUSTOMERS', l_transaction, USER, SYSDATE);
+END;
+")
+        {
+            ExpectedResult = @"CREATE OR REPLACE TRIGGER customers_audit_trg
+    AFTER 
+    UPDATE OR DELETE 
+    ON customers
+    FOR EACH ROW    
+DECLARE
+   l_transaction VARCHAR2(10);
+BEGIN
+   -- determine the transaction type
+   l_transaction := CASE  
+         WHEN UPDATING THEN 'UPDATE'
+         WHEN DELETING THEN 'DELETE'
+   END;
+
+   -- insert a row into the audit table   
+   INSERT INTO audits (table_name, transaction_name, by_user, transaction_date)
+   VALUES('CUSTOMERS', l_transaction, USER, SYSDATE);
+END;"
+        },
+        // CREATE [OR REPLACE] TYPE
+        new(@"CREATE TYPE customer_typ_demo AS OBJECT
+    ( customer_id        NUMBER(6)
+    , cust_first_name    VARCHAR2(20)
+    , cust_last_name     VARCHAR2(20)
+    , cust_address       CUST_ADDRESS_TYP
+    , phone_numbers      PHONE_LIST_TYP
+    , nls_language       VARCHAR2(3)
+    , nls_territory      VARCHAR2(30)
+    , credit_limit       NUMBER(9,2)
+    , cust_email         VARCHAR2(30)
+    , cust_orders        ORDER_LIST_TYP
+    ) ;
+")
+        {
+            ExpectedResult = @"CREATE TYPE customer_typ_demo AS OBJECT
+    ( customer_id        NUMBER(6)
+    , cust_first_name    VARCHAR2(20)
+    , cust_last_name     VARCHAR2(20)
+    , cust_address       CUST_ADDRESS_TYP
+    , phone_numbers      PHONE_LIST_TYP
+    , nls_language       VARCHAR2(3)
+    , nls_territory      VARCHAR2(30)
+    , credit_limit       NUMBER(9,2)
+    , cust_email         VARCHAR2(30)
+    , cust_orders        ORDER_LIST_TYP
+    )"
         }
     };
 }

--- a/Qsi.Tests/Vendor/Oracle/OracleScriptParserTest.Data.cs
+++ b/Qsi.Tests/Vendor/Oracle/OracleScriptParserTest.Data.cs
@@ -7,9 +7,9 @@ public partial class OracleScriptParserTest
     private static readonly TestCaseData[] Parse_TestDatas =
     {
         // SELECT
-        new("SELECT 1 FROM DUAL;;") { ExpectedResult = "SELECT 1 FROM DUAL" },
+        new("SELECT 1 FROM DUAL;;") { ExpectedResult = new[] { "SELECT 1 FROM DUAL" } },
         // CREATE TABLE
-        new("CREATE TABLE a(id NUMBER);") { ExpectedResult = "CREATE TABLE a(id NUMBER)" },
+        new("CREATE TABLE a(id NUMBER);") { ExpectedResult = new[] { "CREATE TABLE a(id NUMBER)" } },
         // CREATE [OR REPLACE] PROCEDURE
         new(@"
 CREATE OR REPLACE PROCEDURE studentInsert(
@@ -28,7 +28,9 @@ BEGIN
 END;
 ")
         {
-            ExpectedResult = @"CREATE OR REPLACE PROCEDURE studentInsert(
+            ExpectedResult = new[]
+            {
+                @"CREATE OR REPLACE PROCEDURE studentInsert(
     pName pl_student.name%TYPE,
     pKor pl_student.kor%TYPE,
     pEng pl_student.eng%TYPE,
@@ -42,6 +44,7 @@ BEGIN
     );
     COMMIT;
 END;"
+            }
         },
         // CREATE [OR REPLACE] FUNCTION
         new(@"
@@ -62,7 +65,9 @@ END get_complete_address;
 
 ")
         {
-            ExpectedResult = @"CREATE OR REPLACE FUNCTION get_complete_address(in_person_id IN NUMBER) 
+            ExpectedResult = new[]
+            {
+                @"CREATE OR REPLACE FUNCTION get_complete_address(in_person_id IN NUMBER) 
     RETURN VARCHAR2
     IS person_details VARCHAR2(130);
 
@@ -76,6 +81,7 @@ BEGIN
     RETURN(person_details); 
 
 END get_complete_address;"
+            }
         },
         // CREATE [OR REPLACE] PACKAGE
         new(@"
@@ -94,7 +100,9 @@ CREATE OR REPLACE PACKAGE emp_mgmt AS
    no_sal EXCEPTION; 
 END emp_mgmt;  ")
         {
-            ExpectedResult = @"CREATE OR REPLACE PACKAGE emp_mgmt AS 
+            ExpectedResult = new[]
+            {
+                @"CREATE OR REPLACE PACKAGE emp_mgmt AS 
    FUNCTION hire (last_name VARCHAR2, job_id VARCHAR2, 
       manager_id NUMBER, salary NUMBER, 
       commission_pct NUMBER, department_id NUMBER) 
@@ -108,6 +116,7 @@ END emp_mgmt;  ")
    no_comm EXCEPTION; 
    no_sal EXCEPTION; 
 END emp_mgmt;"
+            }
         },
         // CREATE [OR REPLACE] TRIGGER
         new(@"
@@ -131,7 +140,9 @@ BEGIN
 END;
 ")
         {
-            ExpectedResult = @"CREATE OR REPLACE TRIGGER customers_audit_trg
+            ExpectedResult = new[]
+            {
+                @"CREATE OR REPLACE TRIGGER customers_audit_trg
     AFTER 
     UPDATE OR DELETE 
     ON customers
@@ -149,6 +160,7 @@ BEGIN
    INSERT INTO audits (table_name, transaction_name, by_user, transaction_date)
    VALUES('CUSTOMERS', l_transaction, USER, SYSDATE);
 END;"
+            }
         },
         // CREATE [OR REPLACE] TYPE
         new(@"CREATE TYPE customer_typ_demo AS OBJECT
@@ -165,7 +177,9 @@ END;"
     ) ;
 ")
         {
-            ExpectedResult = @"CREATE TYPE customer_typ_demo AS OBJECT
+            ExpectedResult = new[]
+            {
+                @"CREATE TYPE customer_typ_demo AS OBJECT
     ( customer_id        NUMBER(6)
     , cust_first_name    VARCHAR2(20)
     , cust_last_name     VARCHAR2(20)
@@ -177,6 +191,7 @@ END;"
     , cust_email         VARCHAR2(30)
     , cust_orders        ORDER_LIST_TYP
     )"
+            }
         }
     };
 }

--- a/Qsi.Tests/Vendor/Oracle/OracleScriptParserTest.Data.cs
+++ b/Qsi.Tests/Vendor/Oracle/OracleScriptParserTest.Data.cs
@@ -10,6 +10,467 @@ public partial class OracleScriptParserTest
         new("SELECT 1 FROM DUAL;;") { ExpectedResult = new[] { "SELECT 1 FROM DUAL" } },
         // CREATE TABLE
         new("CREATE TABLE a(id NUMBER);") { ExpectedResult = new[] { "CREATE TABLE a(id NUMBER)" } },
+
+        // BLOCK (BEGIN ~ END)
+        new(@"
+BEGIN
+    DBMS_OUTPUT.put_line ('Hello World!');
+END;
+
+BEGIN
+    DBMS_OUTPUT.put_line ('Hello World!');
+END;
+
+BEGIN
+    DBMS_OUTPUT.put_line ('Hello World!');
+END;")
+        {
+            ExpectedResult = new[]
+            {
+                @"BEGIN
+    DBMS_OUTPUT.put_line ('Hello World!');
+END;",
+                @"BEGIN
+    DBMS_OUTPUT.put_line ('Hello World!');
+END;",
+                @"BEGIN
+    DBMS_OUTPUT.put_line ('Hello World!');
+END;"
+            }
+        },
+
+        // BLOCK WITH CASE (CASE ~ END CASE)
+        new(@"DECLARE
+  c_grade CHAR( 1 );
+  c_rank  VARCHAR2( 20 );
+BEGIN
+  c_grade := 'B';
+  CASE c_grade
+  WHEN 'A' THEN
+    c_rank := 'Excellent' ;
+  WHEN 'B' THEN
+    c_rank := 'Very Good' ;
+  WHEN 'C' THEN
+    c_rank := 'Good' ;
+  WHEN 'D' THEN
+    c_rank := 'Fair' ;
+  WHEN 'F' THEN
+    c_rank := 'Poor' ;
+  ELSE
+    c_rank := 'No such grade' ;
+  END CASE;
+  DBMS_OUTPUT.PUT_LINE( c_rank );
+END;
+DECLARE
+  c_grade CHAR( 1 );
+  c_rank  VARCHAR2( 20 );
+BEGIN
+  c_grade := 'B';
+  CASE c_grade
+  WHEN 'A' THEN
+    c_rank := 'Excellent' ;
+  WHEN 'B' THEN
+    c_rank := 'Very Good' ;
+  WHEN 'C' THEN
+    c_rank := 'Good' ;
+  WHEN 'D' THEN
+    c_rank := 'Fair' ;
+  WHEN 'F' THEN
+    c_rank := 'Poor' ;
+  ELSE
+    c_rank := 'No such grade' ;
+  END CASE;
+  DBMS_OUTPUT.PUT_LINE( c_rank );
+END;")
+        {
+            ExpectedResult = new[]
+            {
+                @"DECLARE
+  c_grade CHAR( 1 );
+  c_rank  VARCHAR2( 20 );
+BEGIN
+  c_grade := 'B';
+  CASE c_grade
+  WHEN 'A' THEN
+    c_rank := 'Excellent' ;
+  WHEN 'B' THEN
+    c_rank := 'Very Good' ;
+  WHEN 'C' THEN
+    c_rank := 'Good' ;
+  WHEN 'D' THEN
+    c_rank := 'Fair' ;
+  WHEN 'F' THEN
+    c_rank := 'Poor' ;
+  ELSE
+    c_rank := 'No such grade' ;
+  END CASE;
+  DBMS_OUTPUT.PUT_LINE( c_rank );
+END;",
+                @"DECLARE
+  c_grade CHAR( 1 );
+  c_rank  VARCHAR2( 20 );
+BEGIN
+  c_grade := 'B';
+  CASE c_grade
+  WHEN 'A' THEN
+    c_rank := 'Excellent' ;
+  WHEN 'B' THEN
+    c_rank := 'Very Good' ;
+  WHEN 'C' THEN
+    c_rank := 'Good' ;
+  WHEN 'D' THEN
+    c_rank := 'Fair' ;
+  WHEN 'F' THEN
+    c_rank := 'Poor' ;
+  ELSE
+    c_rank := 'No such grade' ;
+  END CASE;
+  DBMS_OUTPUT.PUT_LINE( c_rank );
+END;"
+            }
+        },
+
+        // BLOCK WITH NULL (NULL;)
+        new(@"BEGIN
+    NULL;
+END;
+
+BEGIN
+    NULL;
+END;")
+        {
+            ExpectedResult = new[]
+            {
+                @"BEGIN
+    NULL;
+END;",
+                @"BEGIN
+    NULL;
+END;"
+            }
+        },
+
+        // BLOCK WITH IF (IF ~ END IF)
+        new(@"DECLARE
+  b_profitable BOOLEAN;
+  n_sales      NUMBER;
+  n_costs      NUMBER;
+BEGIN
+  b_profitable := false;   
+  IF n_sales > n_costs THEN
+    b_profitable := true;
+  END IF;
+END;
+DECLARE
+  b_profitable BOOLEAN;
+  n_sales      NUMBER;
+  n_costs      NUMBER;
+BEGIN
+  b_profitable := false;   
+  IF n_sales > n_costs THEN
+    b_profitable := true;
+  END IF;
+END;")
+        {
+            ExpectedResult = new[]
+            {
+                @"DECLARE
+  b_profitable BOOLEAN;
+  n_sales      NUMBER;
+  n_costs      NUMBER;
+BEGIN
+  b_profitable := false;   
+  IF n_sales > n_costs THEN
+    b_profitable := true;
+  END IF;
+END;",
+                @"DECLARE
+  b_profitable BOOLEAN;
+  n_sales      NUMBER;
+  n_costs      NUMBER;
+BEGIN
+  b_profitable := false;   
+  IF n_sales > n_costs THEN
+    b_profitable := true;
+  END IF;
+END;"
+            }
+        },
+
+        // BLOCK WITH LOOP (LOOP ~ END LOOP)
+        new(@"DECLARE
+NUM1 NUMBER :=1;
+
+BEGIN
+    LOOP
+    DBMS_OUTPUT.PUT_LINE(NUM1);
+    NUM1 := NUM1+1; --NUM = NUM +1
+    EXIT WHEN NUM1 >10;
+    END LOOP;
+END;
+
+DECLARE
+NUM1 NUMBER :=1;
+
+BEGIN
+    LOOP
+    DBMS_OUTPUT.PUT_LINE(NUM1);
+    NUM1 := NUM1+1; --NUM = NUM +1
+    EXIT WHEN NUM1 >10;
+    END LOOP;
+END;")
+        {
+            ExpectedResult = new[]
+            {
+                @"DECLARE
+NUM1 NUMBER :=1;
+
+BEGIN
+    LOOP
+    DBMS_OUTPUT.PUT_LINE(NUM1);
+    NUM1 := NUM1+1; --NUM = NUM +1
+    EXIT WHEN NUM1 >10;
+    END LOOP;
+END;",
+                @"DECLARE
+NUM1 NUMBER :=1;
+
+BEGIN
+    LOOP
+    DBMS_OUTPUT.PUT_LINE(NUM1);
+    NUM1 := NUM1+1; --NUM = NUM +1
+    EXIT WHEN NUM1 >10;
+    END LOOP;
+END;"
+            }
+        },
+
+        // BEGIN ~ { BEGIN ~ END } ~ END
+        new(@"begin
+  -- Make GC_NAB field for Next Action By Dropdown 
+  begin 
+  if 'VARCHAR2' = 'NUMBER' and length('VARCHAR2')>0 and length('')>0 then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NAB VARCHAR2(10, ))'; 
+  elsif ('VARCHAR2' = 'NUMBER' and length('VARCHAR2')>0 and length('')=0) or 
+    'VARCHAR2' = 'VARCHAR2' then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NAB VARCHAR2(10))'; 
+  else 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NAB VARCHAR2)'; 
+  end if; 
+  commit; 
+  end; 
+  -- Make GC_NABID field for Next Action By Dropdown 
+  begin 
+  if 'NUMBER' = 'NUMBER' and length('NUMBER')>0 and length('')>0 then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NABID NUMBER(, ))'; 
+  elsif ('NUMBER' = 'NUMBER' and length('NUMBER')>0 and length('')=0) or 
+    'NUMBER' = 'VARCHAR2' then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NABID NUMBER())'; 
+  else 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NABID NUMBER)'; 
+  end if; 
+  commit; 
+  end;
+end;
+
+
+begin
+  -- Make GC_NAB field for Next Action By Dropdown 
+  begin 
+  if 'VARCHAR2' = 'NUMBER' and length('VARCHAR2')>0 and length('')>0 then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NAB VARCHAR2(10, ))'; 
+  elsif ('VARCHAR2' = 'NUMBER' and length('VARCHAR2')>0 and length('')=0) or 
+    'VARCHAR2' = 'VARCHAR2' then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NAB VARCHAR2(10))'; 
+  else 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NAB VARCHAR2)'; 
+  end if; 
+  commit; 
+  end; 
+  -- Make GC_NABID field for Next Action By Dropdown 
+  begin 
+  if 'NUMBER' = 'NUMBER' and length('NUMBER')>0 and length('')>0 then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NABID NUMBER(, ))'; 
+  elsif ('NUMBER' = 'NUMBER' and length('NUMBER')>0 and length('')=0) or 
+    'NUMBER' = 'VARCHAR2' then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NABID NUMBER())'; 
+  else 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NABID NUMBER)'; 
+  end if; 
+  commit; 
+  end;
+end;
+")
+        {
+            ExpectedResult = new[]
+            {
+                @"begin
+  -- Make GC_NAB field for Next Action By Dropdown 
+  begin 
+  if 'VARCHAR2' = 'NUMBER' and length('VARCHAR2')>0 and length('')>0 then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NAB VARCHAR2(10, ))'; 
+  elsif ('VARCHAR2' = 'NUMBER' and length('VARCHAR2')>0 and length('')=0) or 
+    'VARCHAR2' = 'VARCHAR2' then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NAB VARCHAR2(10))'; 
+  else 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NAB VARCHAR2)'; 
+  end if; 
+  commit; 
+  end; 
+  -- Make GC_NABID field for Next Action By Dropdown 
+  begin 
+  if 'NUMBER' = 'NUMBER' and length('NUMBER')>0 and length('')>0 then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NABID NUMBER(, ))'; 
+  elsif ('NUMBER' = 'NUMBER' and length('NUMBER')>0 and length('')=0) or 
+    'NUMBER' = 'VARCHAR2' then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NABID NUMBER())'; 
+  else 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NABID NUMBER)'; 
+  end if; 
+  commit; 
+  end;
+end;",
+                @"begin
+  -- Make GC_NAB field for Next Action By Dropdown 
+  begin 
+  if 'VARCHAR2' = 'NUMBER' and length('VARCHAR2')>0 and length('')>0 then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NAB VARCHAR2(10, ))'; 
+  elsif ('VARCHAR2' = 'NUMBER' and length('VARCHAR2')>0 and length('')=0) or 
+    'VARCHAR2' = 'VARCHAR2' then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NAB VARCHAR2(10))'; 
+  else 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NAB VARCHAR2)'; 
+  end if; 
+  commit; 
+  end; 
+  -- Make GC_NABID field for Next Action By Dropdown 
+  begin 
+  if 'NUMBER' = 'NUMBER' and length('NUMBER')>0 and length('')>0 then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NABID NUMBER(, ))'; 
+  elsif ('NUMBER' = 'NUMBER' and length('NUMBER')>0 and length('')=0) or 
+    'NUMBER' = 'VARCHAR2' then 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NABID NUMBER())'; 
+  else 
+    execute immediate 'alter table ""SERVICEMAIL6"".""ETD_GUESTCARE"" add(GC_NABID NUMBER)'; 
+  end if; 
+  commit; 
+  end;
+end;"
+            }
+        },
+
+        // BLOCK WITH CLOSE CURSOR (CLOSE <CURSOR>)
+        new(@"CREATE OR REPLACE Function FindCourse
+   ( name_in IN varchar2 )
+   RETURN number
+IS
+   cnumber number;
+
+   CURSOR c1
+   IS
+     SELECT course_number
+     FROM courses_tbl
+     WHERE course_name = name_in;
+
+BEGIN
+
+   OPEN c1;
+   FETCH c1 INTO cnumber;
+
+   if c1%notfound then
+      cnumber := 9999;
+   end if;
+
+   CLOSE c1;
+
+RETURN cnumber;
+
+END;
+
+CREATE OR REPLACE Function FindCourse
+   ( name_in IN varchar2 )
+   RETURN number
+IS
+   cnumber number;
+
+   CURSOR c1
+   IS
+     SELECT course_number
+     FROM courses_tbl
+     WHERE course_name = name_in;
+
+BEGIN
+
+   OPEN c1;
+   FETCH c1 INTO cnumber;
+
+   if c1%notfound then
+      cnumber := 9999;
+   end if;
+
+   CLOSE c1;
+
+RETURN cnumber;
+
+END;")
+        {
+            ExpectedResult = new[]
+            {
+                @"CREATE OR REPLACE Function FindCourse
+   ( name_in IN varchar2 )
+   RETURN number
+IS
+   cnumber number;
+
+   CURSOR c1
+   IS
+     SELECT course_number
+     FROM courses_tbl
+     WHERE course_name = name_in;
+
+BEGIN
+
+   OPEN c1;
+   FETCH c1 INTO cnumber;
+
+   if c1%notfound then
+      cnumber := 9999;
+   end if;
+
+   CLOSE c1;
+
+RETURN cnumber;
+
+END;",
+                @"CREATE OR REPLACE Function FindCourse
+   ( name_in IN varchar2 )
+   RETURN number
+IS
+   cnumber number;
+
+   CURSOR c1
+   IS
+     SELECT course_number
+     FROM courses_tbl
+     WHERE course_name = name_in;
+
+BEGIN
+
+   OPEN c1;
+   FETCH c1 INTO cnumber;
+
+   if c1%notfound then
+      cnumber := 9999;
+   end if;
+
+   CLOSE c1;
+
+RETURN cnumber;
+
+END;"
+            },
+        },
+
         // CREATE [OR REPLACE] PROCEDURE
         new(@"
 CREATE OR REPLACE PROCEDURE studentInsert(
@@ -46,6 +507,7 @@ BEGIN
 END;"
             }
         },
+
         // CREATE [OR REPLACE] FUNCTION
         new(@"
 CREATE OR REPLACE FUNCTION get_complete_address(in_person_id IN NUMBER) 
@@ -83,6 +545,7 @@ BEGIN
 END get_complete_address;"
             }
         },
+
         // CREATE [OR REPLACE] PACKAGE
         new(@"
 CREATE OR REPLACE PACKAGE emp_mgmt AS 
@@ -118,6 +581,7 @@ END emp_mgmt;  ")
 END emp_mgmt;"
             }
         },
+
         // CREATE [OR REPLACE] TRIGGER
         new(@"
 CREATE OR REPLACE TRIGGER customers_audit_trg
@@ -162,6 +626,7 @@ BEGIN
 END;"
             }
         },
+
         // CREATE [OR REPLACE] TYPE
         new(@"CREATE TYPE customer_typ_demo AS OBJECT
     ( customer_id        NUMBER(6)

--- a/Qsi.Tests/Vendor/Oracle/OracleScriptParserTest.Data.cs
+++ b/Qsi.Tests/Vendor/Oracle/OracleScriptParserTest.Data.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+
+namespace Qsi.Tests.Oracle;
+
+public partial class OracleScriptParserTest
+{
+    private static readonly TestCaseData[] Parse_TestDatas =
+    {
+        new("SELECT 1 FROM DUAL;;") { ExpectedResult = "SELECT 1 FROM DUAL" },
+        new("CREATE TABLE a(id NUMBER);") { ExpectedResult = "CREATE TABLE a(id NUMBER);" },
+        new(@"
+CREATE OR REPLACE PROCEDURE studentInsert(
+    pName pl_student.name%TYPE,
+    pKor pl_student.kor%TYPE,
+    pEng pl_student.eng%TYPE,
+    pMath pl_student.math%TYPE
+)
+IS
+BEGIN
+    INSERT INTO pl_student VALUES(
+        (SELECT NVL(MAX(hakbun)+1,1) FROM pl_student),
+       pName,pKor,pEng,pMath
+    );
+    COMMIT;
+END;
+")
+        {
+            ExpectedResult = @"CREATE OR REPLACE PROCEDURE studentInsert(
+    pName pl_student.name%TYPE,
+    pKor pl_student.kor%TYPE,
+    pEng pl_student.eng%TYPE,
+    pMath pl_student.math%TYPE
+)
+IS
+BEGIN
+    INSERT INTO pl_student VALUES(
+        (SELECT NVL(MAX(hakbun)+1,1) FROM pl_student),
+       pName,pKor,pEng,pMath
+    );
+    COMMIT;
+END;"
+        }
+    };
+}

--- a/Qsi.Tests/Vendor/Oracle/OracleScriptParserTest.cs
+++ b/Qsi.Tests/Vendor/Oracle/OracleScriptParserTest.cs
@@ -1,0 +1,20 @@
+using System.Linq;
+using NUnit.Framework;
+using Qsi.Data;
+using Qsi.Oracle;
+
+namespace Qsi.Tests.Oracle;
+
+public partial class OracleScriptParserTest
+{
+    [TestCaseSource(nameof(Parse_TestDatas))]
+    public string Test_Parse(string sql)
+    {
+        var parser = new OracleScriptParser();
+        QsiScript[] scripts = parser.Parse(sql, default).ToArray();
+
+        Assert.AreEqual(1, scripts.Length);
+
+        return scripts[0].Script;
+    }
+}

--- a/Qsi.Tests/Vendor/Oracle/OracleScriptParserTest.cs
+++ b/Qsi.Tests/Vendor/Oracle/OracleScriptParserTest.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using NUnit.Framework;
-using Qsi.Data;
 using Qsi.Oracle;
 
 namespace Qsi.Tests.Oracle;
@@ -8,13 +7,12 @@ namespace Qsi.Tests.Oracle;
 public partial class OracleScriptParserTest
 {
     [TestCaseSource(nameof(Parse_TestDatas))]
-    public string Test_Parse(string sql)
+    public string[] Test_Parse(string sql)
     {
         var parser = new OracleScriptParser();
-        QsiScript[] scripts = parser.Parse(sql, default).ToArray();
 
-        Assert.AreEqual(1, scripts.Length);
-
-        return scripts[0].Script;
+        return parser.Parse(sql, default)
+            .Select(x => x.Script)
+            .ToArray();
     }
 }


### PR DESCRIPTION
Issue link: https://chequer.atlassian.net/browse/QP-1152

- 오라클 벤더의 OracleScriptParser에서 Script를 Parse할때, CREATE 구문에서 특정 CREATE 구문(CREATE PROCEDURE 등)의 구문 끝에 세미콜론이 빠지게 되는 현상이 수정되었습니다.