### PR TITLE
[QP-1239] Add ExecuteOptions parameter to QsiRepositoryProvider

### DIFF
--- a/Qsi.Cql/Analyzers/CqlActionAnalyzer.cs
+++ b/Qsi.Cql/Analyzers/CqlActionAnalyzer.cs
@@ -320,7 +320,7 @@ namespace Qsi.Cql.Analyzers
             var script = new QsiScript(sql, QsiScriptType.Select);
 
             // TODO: Bind parameter in selector
-            var table = await context.Engine.RepositoryProvider.GetDataTable(script, null, context.CancellationToken);
+            var table = await context.Engine.RepositoryProvider.GetDataTable(script, null, context.ExecuteOptions, context.CancellationToken);
             QsiDataValue[] values = table.Rows[0].Items;
 
             for (int i = 0; i < values.Length; i++)

--- a/Qsi.Debugger/Vendor/Athena/AthenaRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Athena/AthenaRepositoryProvider.cs
@@ -1,12 +1,13 @@
 using System;
 using Qsi.Data;
 using Qsi.Data.Object;
+using Qsi.Engines;
 
 namespace Qsi.Debugger.Vendor.Athena
 {
     internal class AthenaRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
             identifier = identifier.Level switch
             {

--- a/Qsi.Debugger/Vendor/Athena/AthenaRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Athena/AthenaRepositoryProvider.cs
@@ -7,7 +7,7 @@ namespace Qsi.Debugger.Vendor.Athena
 {
     internal class AthenaRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
             identifier = identifier.Level switch
             {

--- a/Qsi.Debugger/Vendor/Cql/CqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Cql/CqlRepositoryProvider.cs
@@ -1,12 +1,13 @@
 ﻿using Qsi.Data;
 using Qsi.Data.Object;
+using Qsi.Engines;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.Cql
 {
     internal class CqlRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
             // TODO: has search path ?
             return identifier;

--- a/Qsi.Debugger/Vendor/Cql/CqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Cql/CqlRepositoryProvider.cs
@@ -7,7 +7,7 @@ namespace Qsi.Debugger.Vendor.Cql
 {
     internal class CqlRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
             // TODO: has search path ?
             return identifier;

--- a/Qsi.Debugger/Vendor/Hana/HanaRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Hana/HanaRepositoryProvider.cs
@@ -8,7 +8,7 @@ namespace Qsi.Debugger.Vendor.Hana
 {
     internal class HanaRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
             // TODO: has search path ?
             return identifier;

--- a/Qsi.Debugger/Vendor/Hana/HanaRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Hana/HanaRepositoryProvider.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using Qsi.Data;
 using Qsi.Data.Object;
+using Qsi.Engines;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.Hana
 {
     internal class HanaRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
             // TODO: has search path ?
             return identifier;

--- a/Qsi.Debugger/Vendor/Impala/ImpalaRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Impala/ImpalaRepositoryProvider.cs
@@ -8,7 +8,7 @@ namespace Qsi.Debugger.Vendor.Impala
 {
     internal class ImpalaRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
             if (identifier.Level == 1)
             {

--- a/Qsi.Debugger/Vendor/Impala/ImpalaRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Impala/ImpalaRepositoryProvider.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using Qsi.Data;
 using Qsi.Data.Object;
+using Qsi.Engines;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.Impala
 {
     internal class ImpalaRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
             if (identifier.Level == 1)
             {

--- a/Qsi.Debugger/Vendor/MySql/MySqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/MySql/MySqlRepositoryProvider.cs
@@ -97,7 +97,7 @@ namespace Qsi.Debugger.Vendor.MySql
             return null;
         }
 
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
             if (identifier.Level == 1)
             {

--- a/Qsi.Debugger/Vendor/MySql/MySqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/MySql/MySqlRepositoryProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Qsi.Data;
 using System;
 using Qsi.Data.Object;
+using Qsi.Engines;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.MySql
@@ -96,7 +97,7 @@ namespace Qsi.Debugger.Vendor.MySql
             return null;
         }
 
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
             if (identifier.Level == 1)
             {

--- a/Qsi.Debugger/Vendor/Oracle/OracleRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Oracle/OracleRepositoryProvider.cs
@@ -2,13 +2,14 @@
 using Qsi.Data;
 using Qsi.Data.Object;
 using Qsi.Data.Object.Sequence;
+using Qsi.Engines;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.Oracle
 {
     internal class OracleRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
             identifier = identifier.Level switch
             {

--- a/Qsi.Debugger/Vendor/Oracle/OracleRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Oracle/OracleRepositoryProvider.cs
@@ -9,7 +9,7 @@ namespace Qsi.Debugger.Vendor.Oracle
 {
     internal class OracleRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
             identifier = identifier.Level switch
             {

--- a/Qsi.Debugger/Vendor/PhoenixSql/PhoenixSqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/PhoenixSql/PhoenixSqlRepositoryProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Qsi.Data;
 using Qsi.Data.Object;
+using Qsi.Engines;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.PhoenixSql
@@ -63,7 +64,7 @@ namespace Qsi.Debugger.Vendor.PhoenixSql
             return null;
         }
 
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
             return identifier;
         }

--- a/Qsi.Debugger/Vendor/PhoenixSql/PhoenixSqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/PhoenixSql/PhoenixSqlRepositoryProvider.cs
@@ -64,7 +64,7 @@ namespace Qsi.Debugger.Vendor.PhoenixSql
             return null;
         }
 
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
             return identifier;
         }

--- a/Qsi.Debugger/Vendor/PostgreSql/PostgreSqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/PostgreSql/PostgreSqlRepositoryProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Qsi.Data;
 using Qsi.Data.Object;
+using Qsi.Engines;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.PostgreSql
@@ -294,7 +295,7 @@ namespace Qsi.Debugger.Vendor.PostgreSql
             return null;
         }
 
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
             identifier = identifier.Level switch
             {

--- a/Qsi.Debugger/Vendor/PostgreSql/PostgreSqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/PostgreSql/PostgreSqlRepositoryProvider.cs
@@ -295,7 +295,7 @@ namespace Qsi.Debugger.Vendor.PostgreSql
             return null;
         }
 
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
             identifier = identifier.Level switch
             {

--- a/Qsi.Debugger/Vendor/PrimarSql/PrimarSqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/PrimarSql/PrimarSqlRepositoryProvider.cs
@@ -1,12 +1,13 @@
 ﻿using Qsi.Data;
 using Qsi.Data.Object;
+using Qsi.Engines;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.PrimarSql
 {
     internal class PrimarSqlRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
             return identifier;
         }

--- a/Qsi.Debugger/Vendor/PrimarSql/PrimarSqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/PrimarSql/PrimarSqlRepositoryProvider.cs
@@ -7,7 +7,7 @@ namespace Qsi.Debugger.Vendor.PrimarSql
 {
     internal class PrimarSqlRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
             return identifier;
         }

--- a/Qsi.Debugger/Vendor/SqlServer/SqlServerRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/SqlServer/SqlServerRepositoryProvider.cs
@@ -8,7 +8,7 @@ namespace Qsi.Debugger.Vendor.SqlServer
 {
     internal class SqlServerRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
             identifier = identifier.Level switch
             {

--- a/Qsi.Debugger/Vendor/SqlServer/SqlServerRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/SqlServer/SqlServerRepositoryProvider.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using Qsi.Data;
 using Qsi.Data.Object;
+using Qsi.Engines;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.SqlServer
 {
     internal class SqlServerRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
             identifier = identifier.Level switch
             {

--- a/Qsi.Debugger/Vendor/Trino/TrinoRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Trino/TrinoRepositoryProvider.cs
@@ -8,7 +8,7 @@ namespace Qsi.Debugger.Vendor.Trino
 {
     internal class TrinoRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
             identifier = identifier.Level switch
             {

--- a/Qsi.Debugger/Vendor/Trino/TrinoRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/Trino/TrinoRepositoryProvider.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using Qsi.Data;
 using Qsi.Data.Object;
+using Qsi.Engines;
 using Qsi.Utilities;
 
 namespace Qsi.Debugger.Vendor.Trino
 {
     internal class TrinoRepositoryProvider : VendorRepositoryProvider
     {
-        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
             identifier = identifier.Level switch
             {

--- a/Qsi.Debugger/Vendor/VendorRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/VendorRepositoryProvider.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Qsi.Data;
+using Qsi.Engines;
 using Qsi.Services;
 using Qsi.Utilities;
 
@@ -26,13 +27,13 @@ namespace Qsi.Debugger.Vendor
     {
         public event EventHandler<DataTableRequestEventArgs> DataReaderRequested;
 
-        protected sealed override Task<QsiDataTable> GetDataTable(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken)
+        protected sealed override Task<QsiDataTable> GetDataTable(QsiScript script, QsiParameter[] parameters, ExecuteOptions executeOptions, CancellationToken cancellationToken)
         {
             DataReaderRequested?.Invoke(this, new DataTableRequestEventArgs(script, parameters));
             throw new NotImplementedException();
         }
 
-        protected override Task<IDataReader> GetDataReaderAsync(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken)
+        protected override Task<IDataReader> GetDataReaderAsync(QsiScript script, QsiParameter[] parameters, ExecuteOptions executeOptions, CancellationToken cancellationToken)
         {
             DataReaderRequested?.Invoke(this, new DataTableRequestEventArgs(script, parameters));
             throw new NotImplementedException();

--- a/Qsi.Tests/Vendor/MySql/Driver/MySqlRepositoryProvider.cs
+++ b/Qsi.Tests/Vendor/MySql/Driver/MySqlRepositoryProvider.cs
@@ -15,7 +15,7 @@ public class MySqlRepositoryProvider : RepositoryProviderDriverBase
     {
     }
 
-    protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+    protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
     {
         if (identifier.Level == 2 || string.IsNullOrEmpty(Connection.Database))
             return identifier;

--- a/Qsi.Tests/Vendor/MySql/Driver/MySqlRepositoryProvider.cs
+++ b/Qsi.Tests/Vendor/MySql/Driver/MySqlRepositoryProvider.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using MySql.Data.MySqlClient;
 using Qsi.Data;
 using Qsi.Data.Object;
+using Qsi.Engines;
 using Qsi.Utilities;
 
 namespace Qsi.Tests.Vendor.MySql.Driver;
@@ -14,7 +15,7 @@ public class MySqlRepositoryProvider : RepositoryProviderDriverBase
     {
     }
 
-    protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+    protected override QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
     {
         if (identifier.Level == 2 || string.IsNullOrEmpty(Connection.Database))
             return identifier;

--- a/Qsi.Tests/Vendor/RepositoryProviderDriverBase.cs
+++ b/Qsi.Tests/Vendor/RepositoryProviderDriverBase.cs
@@ -5,6 +5,7 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Qsi.Data;
+using Qsi.Engines;
 using Qsi.Services;
 using Qsi.Utilities;
 
@@ -44,10 +45,10 @@ public abstract class RepositoryProviderDriverBase : QsiRepositoryProviderBase
         Connection = connection;
     }
 
-    protected override async Task<QsiDataTable> GetDataTable(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken)
+    protected override async Task<QsiDataTable> GetDataTable(QsiScript script, QsiParameter[] parameters, ExecuteOptions executeOptions, CancellationToken cancellationToken)
     {
         var structure = new QsiTableStructure();
-        using var reader = await GetDataReaderAsync(script, parameters, cancellationToken);
+        using var reader = await GetDataReaderAsync(script, parameters, executeOptions, cancellationToken);
 
         for (int i = 0; i < reader.FieldCount; i++)
         {
@@ -94,7 +95,7 @@ public abstract class RepositoryProviderDriverBase : QsiRepositoryProviderBase
         return QsiDataType.Unknown;
     }
 
-    protected override Task<IDataReader> GetDataReaderAsync(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken)
+    protected override Task<IDataReader> GetDataReaderAsync(QsiScript script, QsiParameter[] parameters, ExecuteOptions executeOptions, CancellationToken cancellationToken)
     {
         ScriptHistories.Add(script);
         return GetDataReaderCoreAsync(script, parameters, cancellationToken);

--- a/Qsi/Analyzers/Action/QsiActionAnalyzer.cs
+++ b/Qsi/Analyzers/Action/QsiActionAnalyzer.cs
@@ -966,7 +966,7 @@ namespace Qsi.Analyzers.Action
                 .Select(identifier =>
                 {
                     var qualifiedIdentifier = new QsiQualifiedIdentifier(identifier.Append(fakeRefIdentifier));
-                    qualifiedIdentifier = context.Engine.RepositoryProvider.ResolveQualifiedIdentifier(qualifiedIdentifier);
+                    qualifiedIdentifier = context.Engine.RepositoryProvider.ResolveQualifiedIdentifier(qualifiedIdentifier, ExecuteOption);
                     return new QsiQualifiedIdentifier(qualifiedIdentifier[..^1]);
                 })
                 .ToArray();

--- a/Qsi/Analyzers/Context/AnalyzerContext.cs
+++ b/Qsi/Analyzers/Context/AnalyzerContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Qsi.Data;
 using Qsi.Engines;
@@ -17,7 +18,9 @@ namespace Qsi.Analyzers.Context
 
         public IQsiTreeNode Tree { get; }
 
-        public QsiAnalyzerOptions Options { get; }
+        public QsiAnalyzerOptions AnalyzerOptions { get; }
+
+        public ExecuteOptions ExecuteOptions { get; }
 
         public CancellationToken CancellationToken { get; }
 
@@ -26,14 +29,16 @@ namespace Qsi.Analyzers.Context
             QsiScript script,
             IReadOnlyDictionary<IQsiBindParameterExpressionNode, QsiParameter> parameters,
             IQsiTreeNode tree,
-            QsiAnalyzerOptions options,
+            QsiAnalyzerOptions analyzerOptions,
+            ExecuteOptions executeOptions,
             CancellationToken cancellationToken)
         {
             Engine = engine;
             Script = script;
             Parameters = parameters;
             Tree = tree;
-            Options = options ?? throw new ArgumentNullException(nameof(options));
+            AnalyzerOptions = analyzerOptions ?? throw new ArgumentNullException(nameof(analyzerOptions));
+            ExecuteOptions = executeOptions ?? new ExecuteOptions();
             CancellationToken = cancellationToken;
         }
     }

--- a/Qsi/Analyzers/Context/AnalyzerContextWrapper.cs
+++ b/Qsi/Analyzers/Context/AnalyzerContextWrapper.cs
@@ -16,20 +16,22 @@ namespace Qsi.Analyzers.Context
 
         public IQsiTreeNode Tree => _context.Tree;
 
-        public QsiAnalyzerOptions Options { get; }
+        public QsiAnalyzerOptions AnalyzerOptions { get; }
+
+        public ExecuteOptions ExecuteOptions => _context.ExecuteOptions;
 
         public CancellationToken CancellationToken => _context.CancellationToken;
 
         private readonly IAnalyzerContext _context;
 
-        protected AnalyzerContextWrapper(IAnalyzerContext context) : this(context, context.Options)
+        protected AnalyzerContextWrapper(IAnalyzerContext context) : this(context, context.AnalyzerOptions)
         {
         }
 
         protected AnalyzerContextWrapper(IAnalyzerContext context, QsiAnalyzerOptions options)
         {
             _context = context;
-            Options = options;
+            AnalyzerOptions = options;
         }
     }
 }

--- a/Qsi/Analyzers/Context/IAnalyzerContext.cs
+++ b/Qsi/Analyzers/Context/IAnalyzerContext.cs
@@ -16,7 +16,9 @@ namespace Qsi.Analyzers.Context
 
         IQsiTreeNode Tree { get; }
 
-        QsiAnalyzerOptions Options { get; }
+        QsiAnalyzerOptions AnalyzerOptions { get; }
+
+        ExecuteOptions ExecuteOptions { get; }
 
         CancellationToken CancellationToken { get; }
     }

--- a/Qsi/Analyzers/IQsiAnalyzer.cs
+++ b/Qsi/Analyzers/IQsiAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Qsi.Data;
+using Qsi.Engines;
 using Qsi.Tree;
 
 namespace Qsi.Analyzers
@@ -13,7 +14,8 @@ namespace Qsi.Analyzers
             QsiScript script,
             QsiParameter[] parameters,
             IQsiTreeNode tree,
-            QsiAnalyzerOptions options,
+            QsiAnalyzerOptions analyzerOptions,
+            ExecuteOptions executeOptions,
             CancellationToken cancellationToken = default
         );
     }

--- a/Qsi/Analyzers/QsiAnalyzerBase.cs
+++ b/Qsi/Analyzers/QsiAnalyzerBase.cs
@@ -19,6 +19,8 @@ namespace Qsi.Analyzers
 
         protected IEqualityComparer<QsiQualifiedIdentifier> QualifiedIdentifierComparer => _qualifiedIdentifierComparer.Value;
 
+        protected ExecuteOption ExecuteOption => _engine.ExecuteOption;
+
         private readonly QsiEngine _engine;
         private readonly Lazy<IEqualityComparer<QsiIdentifier>> _identifierComparer;
         private readonly Lazy<IEqualityComparer<QsiQualifiedIdentifier>> _qualifiedIdentifierComparer;

--- a/Qsi/Analyzers/QsiAnalyzerBase.cs
+++ b/Qsi/Analyzers/QsiAnalyzerBase.cs
@@ -19,8 +19,6 @@ namespace Qsi.Analyzers
 
         protected IEqualityComparer<QsiQualifiedIdentifier> QualifiedIdentifierComparer => _qualifiedIdentifierComparer.Value;
 
-        protected ExecuteOption ExecuteOption => _engine.ExecuteOption;
-
         private readonly QsiEngine _engine;
         private readonly Lazy<IEqualityComparer<QsiIdentifier>> _identifierComparer;
         private readonly Lazy<IEqualityComparer<QsiQualifiedIdentifier>> _qualifiedIdentifierComparer;
@@ -36,7 +34,8 @@ namespace Qsi.Analyzers
             QsiScript script,
             QsiParameter[] parameters,
             IQsiTreeNode tree,
-            QsiAnalyzerOptions options,
+            QsiAnalyzerOptions analyzerOptions,
+            ExecuteOptions executeOptions,
             CancellationToken cancellationToken = default)
         {
             if (!CanExecute(script, tree))
@@ -48,7 +47,8 @@ namespace Qsi.Analyzers
                     script,
                     BindParameters(tree, parameters),
                     tree,
-                    options,
+                    analyzerOptions,
+                    executeOptions,
                     cancellationToken
                 )
             );
@@ -107,7 +107,7 @@ namespace Qsi.Analyzers
             // │         └-> identifier(2)        └-> table.Identifier(3) │
             // └──────────────────────────────────────────────────────────┘ 
 
-            if (context.Options.UseExplicitRelationAccess)
+            if (context.AnalyzerOptions.UseExplicitRelationAccess)
                 return false;
 
             if (!QsiUtility.IsReferenceType(table.Type))

--- a/Qsi/Analyzers/Table/Context/TableCompileContext.cs
+++ b/Qsi/Analyzers/Table/Context/TableCompileContext.cs
@@ -21,7 +21,7 @@ namespace Qsi.Analyzers.Table.Context
         private readonly List<QsiTableStructure> _directives;
         private Stack<QsiQualifiedIdentifier> _identifierScope;
 
-        public TableCompileContext(IAnalyzerContext context) : this(context, context.Options)
+        public TableCompileContext(IAnalyzerContext context) : this(context, context.AnalyzerOptions)
         {
         }
 
@@ -33,7 +33,7 @@ namespace Qsi.Analyzers.Table.Context
             JoinedSouceTables = new List<QsiTableStructure>();
         }
 
-        public TableCompileContext(TableCompileContext context) : this(context, context.Options)
+        public TableCompileContext(TableCompileContext context) : this(context, context.AnalyzerOptions)
         {
             Parent = context;
             Depth = context.Depth + 1;

--- a/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
+++ b/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
@@ -1044,7 +1044,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
             identifier = new QsiQualifiedIdentifier(identifiers.ToArray());
         }
 
-        return context.Engine.RepositoryProvider.ResolveQualifiedIdentifier(identifier);
+        return context.Engine.RepositoryProvider.ResolveQualifiedIdentifier(identifier, ExecuteOption);
     }
 
     private QsiTableStructure ResolveTableStructure(TableCompileContext context, QsiQualifiedIdentifier identifier)

--- a/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
+++ b/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
@@ -80,7 +80,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
         var lookup = ResolveTableStructure(context, table.Identifier);
 
         // view
-        if (context.Options.UseViewTracing &&
+        if (context.AnalyzerOptions.UseViewTracing &&
             !lookup.IsSystem &&
             lookup.Type is QsiTableType.View or QsiTableType.MaterializedView)
         {
@@ -152,7 +152,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
 
         if (alias == null &&
             table.Parent is IQsiDerivedColumnNode &&
-            !context.Options.AllowNoAliasInDerivedTable)
+            !context.AnalyzerOptions.AllowNoAliasInDerivedTable)
         {
             throw new QsiException(QsiError.NoAlias);
         }
@@ -180,7 +180,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
 
         if (columns == null || columns.Count == 0)
         {
-            if (!context.Options.AllowEmptyColumnsInSelect)
+            if (!context.AnalyzerOptions.AllowEmptyColumnsInSelect)
             {
                 throw new QsiException(QsiError.Syntax);
             }
@@ -294,7 +294,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
 
         if (alias == null &&
             table.Parent is IQsiDerivedColumnNode &&
-            !context.Options.AllowNoAliasInDerivedTable)
+            !context.AnalyzerOptions.AllowNoAliasInDerivedTable)
         {
             throw new QsiException(QsiError.NoAlias);
         }
@@ -345,7 +345,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
 
         if ((columnCount ?? 0) == 0)
         {
-            if (!context.Options.AllowEmptyColumnsInInline)
+            if (!context.AnalyzerOptions.AllowEmptyColumnsInInline)
                 throw new QsiException(QsiError.NoColumnsSpecified, alias);
 
             columnCount = 0;
@@ -435,7 +435,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
 
                 if (ContainsRecursiveQuery(compositeTableNode.Sources[0], cteName))
                 {
-                    if (!context.Options.UseAutoFixRecursiveQuery || compositeTableNode.Sources.Length < 2)
+                    if (!context.AnalyzerOptions.UseAutoFixRecursiveQuery || compositeTableNode.Sources.Length < 2)
                         throw new QsiException(QsiError.NoAnchorInRecursiveQuery, cteName);
 
                     var fixedSources = compositeTableNode.Sources
@@ -762,7 +762,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
             throw new QsiException(QsiError.UnknownColumnIn, "null", scopeFieldList);
 
         IEnumerable<TableCompileContext> candidateContexts =
-            context.Options.UseOuterQueryColumn ? context.AncestorsAndSelf() : new[] { context };
+            context.AnalyzerOptions.UseOuterQueryColumn ? context.AncestorsAndSelf() : new[] { context };
 
         var lastName = column.Name[^1];
 
@@ -808,7 +808,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
 
         // NOTE: 'SELECT actor FROM actor' same as
         //       'SELECT actor.* FROM actor'
-        if (context.Options.UseImplicitTableWildcardInSelect)
+        if (context.AnalyzerOptions.UseImplicitTableWildcardInSelect)
             return ImplicitlyResolveColumnReference(context, column, out implicitTableWildcardTarget);
 
         throw new QsiException(QsiError.UnknownColumnIn, lastName.Value, scopeFieldList);
@@ -1044,7 +1044,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
             identifier = new QsiQualifiedIdentifier(identifiers.ToArray());
         }
 
-        return context.Engine.RepositoryProvider.ResolveQualifiedIdentifier(identifier, ExecuteOption);
+        return context.Engine.RepositoryProvider.ResolveQualifiedIdentifier(identifier, context.ExecuteOptions);
     }
 
     private QsiTableStructure ResolveTableStructure(TableCompileContext context, QsiQualifiedIdentifier identifier)

--- a/Qsi/Engines/ExecuteOption.cs
+++ b/Qsi/Engines/ExecuteOption.cs
@@ -1,8 +1,0 @@
-using System.Data.Common;
-
-namespace Qsi.Engines;
-
-public class ExecuteOption
-{
-    public DbConnection Connection { get; set; }
-}

--- a/Qsi/Engines/ExecuteOption.cs
+++ b/Qsi/Engines/ExecuteOption.cs
@@ -1,0 +1,8 @@
+using System.Data.Common;
+
+namespace Qsi.Engines;
+
+public class ExecuteOption
+{
+    public DbConnection Connection { get; set; }
+}

--- a/Qsi/Engines/ExecuteOptions.cs
+++ b/Qsi/Engines/ExecuteOptions.cs
@@ -1,0 +1,13 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Qsi.Engines;
+
+public class ExecuteOptions
+{
+    [AllowNull]
+    public DbConnection Connection { get; set; }
+
+    [AllowNull]
+    public string SchemaName { get; set; }
+}

--- a/Qsi/Engines/Explain/Analyzers/ExplainActionAnalyzer.cs
+++ b/Qsi/Engines/Explain/Analyzers/ExplainActionAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Qsi.Analyzers;

--- a/Qsi/Engines/Explain/Analyzers/ExplainActionAnalyzer.cs
+++ b/Qsi/Engines/Explain/Analyzers/ExplainActionAnalyzer.cs
@@ -26,10 +26,11 @@ namespace Qsi.Engines.Explain
             QsiScript script,
             QsiParameter[] parameters,
             IQsiTreeNode tree,
-            QsiAnalyzerOptions options,
+            QsiAnalyzerOptions analyzerOptions,
+            ExecuteOptions executeOptions,
             CancellationToken cancellationToken = default)
         {
-            IQsiAnalysisResult[] results = await _analyzer.Execute(script, parameters, tree, options, cancellationToken);
+            IQsiAnalysisResult[] results = await _analyzer.Execute(script, parameters, tree, analyzerOptions, executeOptions, cancellationToken);
 
             for (int i = 0; i < results.Length; i++)
             {

--- a/Qsi/Engines/Explain/ExplainRepositoryProvider.cs
+++ b/Qsi/Engines/Explain/ExplainRepositoryProvider.cs
@@ -21,9 +21,9 @@ namespace Qsi.Engines.Explain
             _repositoryProvider = repositoryProvider ?? throw new ArgumentNullException(nameof(repositoryProvider));
         }
 
-        public QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        public QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
-            return _repositoryProvider.ResolveQualifiedIdentifier(identifier, executeOption ?? _engine.ExecuteOption);
+            return _repositoryProvider.ResolveQualifiedIdentifier(identifier, executeOptions);
         }
 
         public QsiTableStructure LookupTable(QsiQualifiedIdentifier identifier)
@@ -46,9 +46,13 @@ namespace Qsi.Engines.Explain
             return _repositoryProvider.LookupObject(identifier, type);
         }
 
-        public async Task<QsiDataTable> GetDataTable(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken)
+        public async Task<QsiDataTable> GetDataTable(
+            QsiScript script,
+            QsiParameter[] parameters,
+            ExecuteOptions executeOptions,
+            CancellationToken cancellationToken)
         {
-            IQsiAnalysisResult[] results = await _engine.Explain(script, cancellationToken);
+            IQsiAnalysisResult[] results = await _engine.Explain(script, executeOptions, cancellationToken);
 
             if (results.Length != 1 || results[0] is not QsiTableResult tableResult)
                 throw new QsiException(QsiError.InvalidNestedExplain, script.Script);
@@ -64,9 +68,13 @@ namespace Qsi.Engines.Explain
             return dataTable;
         }
 
-        public async Task<IDataReader> GetDataReaderAsync(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken)
+        public async Task<IDataReader> GetDataReaderAsync(
+            QsiScript script,
+            QsiParameter[] parameters,
+            ExecuteOptions executeOptions,
+            CancellationToken cancellationToken)
         {
-            IQsiAnalysisResult[] results = await _engine.Explain(script, cancellationToken);
+            IQsiAnalysisResult[] results = await _engine.Explain(script, executeOptions, cancellationToken);
 
             if (results.Length != 1 || results[0] is not QsiTableResult tableResult)
                 throw new QsiException(QsiError.InvalidNestedExplain, script.Script);

--- a/Qsi/Engines/Explain/ExplainRepositoryProvider.cs
+++ b/Qsi/Engines/Explain/ExplainRepositoryProvider.cs
@@ -21,9 +21,9 @@ namespace Qsi.Engines.Explain
             _repositoryProvider = repositoryProvider ?? throw new ArgumentNullException(nameof(repositoryProvider));
         }
 
-        public QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        public QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
-            return _repositoryProvider.ResolveQualifiedIdentifier(identifier);
+            return _repositoryProvider.ResolveQualifiedIdentifier(identifier, executeOption ?? _engine.ExecuteOption);
         }
 
         public QsiTableStructure LookupTable(QsiQualifiedIdentifier identifier)

--- a/Qsi/Engines/QsiEngine.cs
+++ b/Qsi/Engines/QsiEngine.cs
@@ -25,6 +25,8 @@ namespace Qsi.Engines
 
         public IQsiLanguageService LanguageService { get; }
 
+        public ExecuteOption ExecuteOption { get; }
+
         internal bool IsExplainEngine => LanguageService is ExplainLanguageService;
 
         private readonly Lazy<IQsiTreeParser> _treeParser;
@@ -33,11 +35,15 @@ namespace Qsi.Engines
         private readonly Lazy<IQsiRepositoryProvider> _repositoryProvider;
         private readonly Lazy<IQsiAnalyzer[]> _analyzers;
 
-        public QsiEngine(IQsiLanguageService languageService) : this(languageService, () => new QsiDataTableMemoryCacheProvider())
+        public QsiEngine(IQsiLanguageService languageService) : this(languageService, new ExecuteOption(), () => new QsiDataTableMemoryCacheProvider())
         {
         }
 
-        public QsiEngine(IQsiLanguageService languageService, Func<IQsiDataTableCacheProvider> cacheProviderFactory)
+        public QsiEngine(IQsiLanguageService languageService, ExecuteOption option) : this(languageService, option, () => new QsiDataTableMemoryCacheProvider())
+        {
+        }
+
+        public QsiEngine(IQsiLanguageService languageService, ExecuteOption option, Func<IQsiDataTableCacheProvider> cacheProviderFactory)
         {
             CacheProviderFactory = cacheProviderFactory;
 
@@ -48,6 +54,8 @@ namespace Qsi.Engines
             _scriptParser = new Lazy<IQsiScriptParser>(LanguageService.CreateScriptParser);
             _repositoryProvider = new Lazy<IQsiRepositoryProvider>(LanguageService.CreateRepositoryProvider);
             _analyzers = new Lazy<IQsiAnalyzer[]>(() => LanguageService.CreateAnalyzers(this).ToArray());
+
+            ExecuteOption = option ?? throw new ArgumentNullException(nameof(option));
         }
 
         public T GetAnalyzer<T>() where T : QsiAnalyzerBase

--- a/Qsi/Services/IQsiRepositoryProvider.cs
+++ b/Qsi/Services/IQsiRepositoryProvider.cs
@@ -10,7 +10,7 @@ namespace Qsi.Services
 {
     public interface IQsiRepositoryProvider
     {
-        QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption);
+        QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions);
 
         QsiTableStructure LookupTable(QsiQualifiedIdentifier identifier);
 
@@ -21,8 +21,8 @@ namespace Qsi.Services
         QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type);
 
         [Obsolete("Use GetDataReader")]
-        Task<QsiDataTable> GetDataTable(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken);
+        Task<QsiDataTable> GetDataTable(QsiScript script, QsiParameter[] parameters, ExecuteOptions executeOptions, CancellationToken cancellationToken);
 
-        Task<IDataReader> GetDataReaderAsync(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken);
+        Task<IDataReader> GetDataReaderAsync(QsiScript script, QsiParameter[] parameters, ExecuteOptions executeOptions, CancellationToken cancellationToken);
     }
 }

--- a/Qsi/Services/IQsiRepositoryProvider.cs
+++ b/Qsi/Services/IQsiRepositoryProvider.cs
@@ -4,12 +4,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Qsi.Data;
 using Qsi.Data.Object;
+using Qsi.Engines;
 
 namespace Qsi.Services
 {
     public interface IQsiRepositoryProvider
     {
-        QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier);
+        QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption);
 
         QsiTableStructure LookupTable(QsiQualifiedIdentifier identifier);
 

--- a/Qsi/Services/QsiRepositoryProviderBase.cs
+++ b/Qsi/Services/QsiRepositoryProviderBase.cs
@@ -19,11 +19,11 @@ namespace Qsi.Services
 
         protected abstract QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type);
 
-        protected abstract QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption);
+        protected abstract QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions options);
 
-        protected abstract Task<QsiDataTable> GetDataTable(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken);
+        protected abstract Task<QsiDataTable> GetDataTable(QsiScript script, QsiParameter[] parameters, ExecuteOptions options, CancellationToken cancellationToken);
 
-        protected abstract Task<IDataReader> GetDataReaderAsync(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken);
+        protected abstract Task<IDataReader> GetDataReaderAsync(QsiScript script, QsiParameter[] parameters, ExecuteOptions options, CancellationToken cancellationToken);
 
         #region IQsiRepositoryProvider
         QsiTableStructure IQsiRepositoryProvider.LookupTable(QsiQualifiedIdentifier identifier)
@@ -64,19 +64,19 @@ namespace Qsi.Services
             return LookupObject(identifier, type);
         }
 
-        QsiQualifiedIdentifier IQsiRepositoryProvider.ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
+        QsiQualifiedIdentifier IQsiRepositoryProvider.ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOptions executeOptions)
         {
-            return ResolveQualifiedIdentifier(identifier, executeOption);
+            return ResolveQualifiedIdentifier(identifier, executeOptions);
         }
 
-        Task<QsiDataTable> IQsiRepositoryProvider.GetDataTable(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken)
+        Task<QsiDataTable> IQsiRepositoryProvider.GetDataTable(QsiScript script, QsiParameter[] parameters, ExecuteOptions executeOptions, CancellationToken cancellationToken)
         {
-            return GetDataTable(script, parameters, cancellationToken);
+            return GetDataTable(script, parameters, executeOptions, cancellationToken);
         }
 
-        Task<IDataReader> IQsiRepositoryProvider.GetDataReaderAsync(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken)
+        Task<IDataReader> IQsiRepositoryProvider.GetDataReaderAsync(QsiScript script, QsiParameter[] parameters, ExecuteOptions executeOptions, CancellationToken cancellationToken)
         {
-            return GetDataReaderAsync(script, parameters, cancellationToken);
+            return GetDataReaderAsync(script, parameters, executeOptions, cancellationToken);
         }
         #endregion
     }

--- a/Qsi/Services/QsiRepositoryProviderBase.cs
+++ b/Qsi/Services/QsiRepositoryProviderBase.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Qsi.Data;
 using Qsi.Data.Object;
+using Qsi.Engines;
 
 namespace Qsi.Services
 {
@@ -18,7 +19,7 @@ namespace Qsi.Services
 
         protected abstract QsiObject LookupObject(QsiQualifiedIdentifier identifier, QsiObjectType type);
 
-        protected abstract QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier);
+        protected abstract QsiQualifiedIdentifier ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption);
 
         protected abstract Task<QsiDataTable> GetDataTable(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken);
 
@@ -63,9 +64,9 @@ namespace Qsi.Services
             return LookupObject(identifier, type);
         }
 
-        QsiQualifiedIdentifier IQsiRepositoryProvider.ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier)
+        QsiQualifiedIdentifier IQsiRepositoryProvider.ResolveQualifiedIdentifier(QsiQualifiedIdentifier identifier, ExecuteOption executeOption)
         {
-            return ResolveQualifiedIdentifier(identifier);
+            return ResolveQualifiedIdentifier(identifier, executeOption);
         }
 
         Task<QsiDataTable> IQsiRepositoryProvider.GetDataTable(QsiScript script, QsiParameter[] parameters, CancellationToken cancellationToken)


### PR DESCRIPTION
## What is this PR
ExecuteOptions를 추가했습니다. ExecuteOptions는 RepositoryProvider의 함수들의 파라미터로 들어가게 되고, RepositoryProvider의 구현체에서 Option에 따라 추가적인 동작을 구현 할 수 있게 합니다.

## Changes

- ExecuteOptions 클래스가 추가 되었습니다.
- IQsiRepositoryProvider의 모든 함수에 ExecuteOptions가 파라미터로 추가됩니다.
- Analyzer의 Context에 ExecuteOptions가 추가되며 RepositoryProvider를 호출할때 해당 Context의 ExecuteOptions를 사용하도록 합니다. 