### PR TITLE
QP-2127 [HANA DB] 특정 SQL구문 사용시 CPU사용이 급증하는 이슈

### DIFF
--- a/Qsi.Hana/Tree/Visitors/ExpressionVisitor.cs
+++ b/Qsi.Hana/Tree/Visitors/ExpressionVisitor.cs
@@ -1536,10 +1536,14 @@ namespace Qsi.Hana.Tree.Visitors
         {
             TreeHelper.VerifyTokenType(token, STRING_LITERAL);
 
+            // NOTE: HANA DB only unescapes '
+            //       ' could be escaped with ''
+            //       Since HANA DB don't predict result's column name
+            //       Don't escape string literal exactly
             var node = new QsiLiteralExpressionNode
             {
                 Type = QsiDataType.String,
-                Value = IdentifierUtility.Unescape(token.Text)
+                Value = token.Text   
             };
 
             HanaTree.PutContextSpan(node, token);

--- a/Qsi.Tests/IdentifierUtilityTests.cs
+++ b/Qsi.Tests/IdentifierUtilityTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using Qsi.Utilities;
 
@@ -56,5 +57,14 @@ public class IdentifierUtilityTests
     public string Test_Unescape(string value)
     {
         return IdentifierUtility.Unescape(value);
+    }
+
+    [TestCase(@"'''")]
+    public void Test_Unescape_Fail(string value)
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            IdentifierUtility.Unescape(value);
+        });
     }
 }

--- a/Qsi/Utilities/IdentifierUtility.cs
+++ b/Qsi/Utilities/IdentifierUtility.cs
@@ -60,6 +60,9 @@ namespace Qsi.Utilities
 
             do
             {
+                if (index >= value.Length - 1)
+                    throw new InvalidOperationException($"Failed to unescape string: {value}");
+                
                 bool end = index == value.Length - 1;
 
                 if (index > 0)


### PR DESCRIPTION
https://chequer.atlassian.net/browse/QP-2127
HANA DB에서 `SELECT * FROM TABLES` 쿼리 실행 시, CPU가 100%를 점유하며 엔진이 느려지거나 먹통이 되는 현상을 해결합니다.

드라이버에서 실행된 쿼리의 결과를 QSI가 분석하다가 무한 대기 상태에 빠지게 되었습니다.

- 문제가 되는 구문은 `T1.NAME LIKE '\_SYS\_REP\_%' ESCAPE '\'` 같은 형태로, 통용적으로 사용되는 `IdentifierUtility.Unescape()`에서 무한루프에 빠지게 되었습니다.
- HANADB에서 사용하는 String Literal 형태는 일반적인 형태와 다르게 literal 그 자체를 사용하며, 유일한 escape character는 ' 로 파악됩니다.
- HANADB는 ColumnName Predicate를 아직 하지 않고있기에, StringLiteral Parse까지는 하지 않습니다. cc @Web-Engine 
- 이 외에도 IdentifierUtility에서 deparse하는 경우 오류가 발생할 수 있기에 방어 로직을 추가합니다.

무한루프에 빠지게 한 근본적인 쿼리또한 공유드립니다.
```
CREATE VIEW SYS.TABLES AS
SELECT A.SCHEMA,
       A.NAME,
       A.OID,
       A.DESCRIPTION,
       A.FIXEDPARTSIZE,
       MAP(A.LOGGING, 0, 'FALSE', 1, 'TRUE', NULL),
       MAP(BITAND(A.TABLETYPE, 1), 1, 'TRUE', 'FALSE'),
       'FALSE',
       CAST(MAP(BITAND(A.TABLETYPE, 16384), 16384, 'HYBRID', 'ROW') AS VARCHAR(16)),
       MAP(BITAND(A.TABLETYPE, 1024), 1024, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLETYPE, 512), 512, 'TRUE', 'FALSE'),
       MAP(A.SHARED, 1, 'TRUE', 'FALSE'),
       CAST('NONE' AS VARCHAR(7)),
       CASE BITAND(A.TABLETYPE, 2176) WHEN 128 THEN 'TRUE' WHEN 2048 THEN 'TRUE' WHEN 2176 THEN 'TRUE' ELSE 'FALSE' END,
       MAP(BITAND(A.TABLETYPE, 2176), 128, 'NO LOGGING', 2176, 'LOCAL', 2048, 'GLOBAL', 'NONE'),
       CAST(MAP(BITAND(A.TABLETYPE, 6272), 128, 'PRESERVE', 2048, 'PRESERVE', 6144, 'DELETE', NULL) AS VARCHAR(8)),
       MAP(BITAND(A.TABLETYPE, 8192), 8192, 'TRUE', 'FALSE'),
       CASE A.CONSTRAINT WHEN 6 THEN 'TRUE' WHEN 7 THEN 'TRUE' WHEN 15 THEN 'TRUE' WHEN 16 THEN 'TRUE' ELSE 'FALSE' END,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       A.UNLOAD_PRIORITY,
       NULL,
       CASE LOCATE(A.NAME, '_SYS_REP_')
           WHEN 1 THEN 'TRUE'
           ELSE MAP(BITAND(A.TABLETYPE, 131072), 131072, 'TRUE', 'FALSE') END,
       MAP(BITAND(A.TABLE_FLAGS, 35184372088832), 35184372088832, 'TRUE', 'FALSE'),
       CASE
           WHEN EXISTS(SELECT TABLE_OID FROM SYS.SERIES_DATA_ SD WHERE SD.TABLE_OID = A.OID) THEN 'TRUE'
           ELSE 'FALSE' END,
       NULL,
       CREATE_TIME,
       CAST(NULL AS VARCHAR(8)) as TEMPORAL_TYPE,
       CASE BITAND(HEXTOBIN(A.TABLE_FLAGS), X'0002000000000000')
           WHEN X'0002000000000000' THEN 'TRUE'
           ELSE 'FALSE' END        HAS_MASKED_COLUMNS,
       NULL,
       MAP(BITAND(A.TABLETYPE, 1048576), 1048576, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLETYPE, 2097152), 2097152, 'TRUE', 'FALSE'),
       NULL,
       MAP(BITAND(A.TABLE_FLAGS, 18014398509481984), 18014398509481984, 'FALSE', 'TRUE'),
       CAST(MAP(BITAND(A.TABLETYPE, 4194304), 4194304, 'PAGE', 'TABLE') AS VARCHAR(7))
FROM (SELECT T1.SCHEMA SCHEMA, T1.NAME NAME, T1.OID OID, T1.DESCRIPTION DESCRIPTION,            T1.FIXEDPARTSIZE FIXEDPARTSIZE, T1.LOGGING LOGGING, T1.TABLETYPE TABLETYPE, T1.SHARED SHARED, I.CONSTRAINT CONSTRAINT,            T1.UNLOAD_PRIORITY UNLOAD_PRIORITY, T1.TABLE_FLAGS TABLE_FLAGS, T1.CREATE_TIME CREATE_TIME
      FROM SYS.RS_TABLES_ T1 LEFT OUTER JOIN SYS.P_INDEXES_ I
      ON ( T1.SCHEMA = I.SCHEMA AND T1.CID = I.CID AND I.CSTABLE = 0 AND I.CONSTRAINT IN (6, 7, 15, 16) )
      WHERE NOT EXISTS (SELECT * FROM SYS.RS_TABLES_ T2 WHERE T1.OID = T2.OID
        AND T1.VID
          < T2.VID
        AND T1.SCHEMA = T2.SCHEMA
        AND T1.NAME = T2.NAME)
        AND (T1.NAME NOT LIKE '\_SYS%' ESCAPE '\'
         OR T1.NAME LIKE '\_SYS\_REP\_%' ESCAPE '\'
         OR T1.SCHEMA = '_SYS_SECURITY'
         OR T1.NAME LIKE '\_SYS\_REPLICATION\_LOG\_%' ESCAPE '\' )
        AND ( CURRENT_USER = 'SYSTEM'
         OR HASSYSTEMPRIVILEGE (CURRENT_USER
          , 'CATALOG READ') = 1
         OR HASSYSTEMPRIVILEGE (CURRENT_USER
          , 'DATA ADMIN') = 1
         OR CURRENT_USER = T1.SCHEMA
         OR T1.SCHEMA IN (SELECT S.SCHEMA_NAME FROM SYS._SYS_SCHEMAS_WITH_PRIVILEGES_ON S)
         OR (T1.OID
          , 'TABLE') IN (SELECT OBJ_ID
          , OBJ_TYPE FROM SYS._SYS_GRANTED_OBJECTS) )) A
UNION ALL
SELECT A.SCHEMA_NAME,
       A.TABLE_NAME,
       A.TABLE_OID,
       A.DESCRIPTION,
       A.FIXED_PART_SIZE,
       MAP(A.LOGGING, 0, 'FALSE', 1, 'TRUE', NULL),
       MAP(BITAND(A.TABLE_TYPE, 1), 1, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_TYPE, 524288), 524288, 'FALSE', 'TRUE'),
       MAP(BITAND(A.TABLE_TYPE, 524288), 524288, 'COLLECTION', 'COLUMN'),
       MAP(BITAND(A.TABLE_TYPE, 1024), 1024, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_TYPE, 512), 512, 'TRUE', 'FALSE'),
       MAP(A.SHARED, 1, 'TRUE', 'FALSE'),
       MAP(TO_BIGINT(A.SESSION_TYPE), 0, 'NONE', 1, 'SIMPLE', 2, 'HISTORY', 'NONE'),
       CASE BITAND(A.TABLE_TYPE, 2176)
           WHEN 128 THEN 'TRUE'
           WHEN 2048 THEN 'TRUE'
           WHEN 2176 THEN 'TRUE'
           ELSE 'FALSE' END,
       MAP(BITAND(A.TABLE_TYPE, 2176), 128, 'NO LOGGING', 2176, 'LOCAL', 2048, 'GLOBAL', 'NONE'),
       CAST(MAP(BITAND(A.TABLE_TYPE, 6272), 128, 'PRESERVE', 2048, 'PRESERVE', 6144, 'DELETE', NULL) AS VARCHAR(8)),
       MAP(BITAND(A.TABLE_TYPE, 8192), 8192, 'TRUE', 'FALSE'),
       CASE A.CONSTRAINT
           WHEN 6 THEN 'TRUE'
           WHEN 7 THEN 'TRUE'
           WHEN 15 THEN 'TRUE'
           WHEN 16 THEN 'TRUE'
           WHEN 28 THEN 'TRUE'
           WHEN 29 THEN 'TRUE'
           ELSE 'FALSE' END,
       A.PARTITION_SPEC,
       MAP(BITAND(A.TABLE_FLAGS, 1024), 1024, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_FLAGS, 65536), 65536, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_FLAGS, 262144), 262144, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_FLAGS, 524288), 524288, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_FLAGS, 2097152), 2097152, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_FLAGS, 67108864), 67108864, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_FLAGS, 536870912), 536870912, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_FLAGS, 1073741824), 1073741824, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_FLAGS, 2147483648), 2147483648, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_FLAGS, 4294967296), 4294967296, 'TRUE', 'FALSE'),
       A.UNLOAD_PRIORITY,
       MAP(BITAND(A.TABLE_FLAGS, 549755813888), 549755813888, 'TRUE', 'FALSE'),
       CASE LOCATE(A.TABLE_NAME, '_SYS_REP_')
           WHEN 1 THEN 'TRUE'
           ELSE MAP(BITAND(A.TABLE_TYPE, 131072), 131072, 'TRUE', 'FALSE') END,
       MAP(BITAND(A.TABLE_FLAGS, 35184372088832), 35184372088832, 'TRUE', 'FALSE'),
       CASE
           WHEN EXISTS(SELECT TABLE_OID FROM SYS.SERIES_DATA_ SD WHERE SD.TABLE_OID = A.TABLE_OID) THEN 'TRUE'
           ELSE 'FALSE' END,
       CASE A.ROW_ORDER_TYPE WHEN 0 THEN NULL WHEN 1 THEN 'BY VALUE' ELSE 'INVALID' END,
       A.CREATE_TIME,
       CAST((CASE
                 WHEN BITAND(TABLE_FLAGS, 36037593111986176) <> 0 THEN 'TEMPORAL'
                 WHEN BITAND(TABLE_FLAGS, 1125899906842624) <> 0 THEN 'HISTORY'
                 ELSE NULL END) AS VARCHAR(8)) AS      TEMPORAL_TYPE,
       CASE BITAND(HEXTOBIN(A.TABLE_FLAGS), X'0002000000000000')
           WHEN X'0002000000000000' THEN 'TRUE'
           ELSE 'FALSE' END                            HAS_MASKED_COLUMNS,
       CASE A.PERSISTENT_MEMORY WHEN 1 THEN 'TRUE' WHEN 2 THEN 'FALSE' ELSE NULL END,
       MAP(BITAND(A.TABLE_TYPE, 1048576), 1048576, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_TYPE, 2097152), 2097152, 'TRUE', 'FALSE'),
       A.NUMA_NODE_INDEXES,
       MAP(BITAND(A.TABLE_FLAGS, 18014398509481984), 18014398509481984, 'FALSE', 'TRUE'),
       CAST(CASE A.LOAD_UNIT
                WHEN 1 THEN 'DEFAULT'
                WHEN 2 THEN 'PAGE'
                WHEN 3 THEN 'COLUMN'
                WHEN 4 THEN 'TABLE' END AS VARCHAR(7)) LOAD_UNIT
FROM (SELECT T1.*, I.CONSTRAINT CONSTRAINT, NN.NUMA_NODE_INDEXES NUMA_NODE_INDEXES
      FROM SYS.CS_TABLES_ T1 LEFT OUTER JOIN SYS.P_INDEXES_ I
      ON ( T1.SCHEMA_NAME = I.SCHEMA AND T1.TABLE_OID = I.CID AND I.CSTABLE = 1 AND I.CONSTRAINT IN (6, 7, 15, 16, 28, 29) ) LEFT OUTER MANY TO ONE JOIN SYS.NUMA_NODE_PREFERENCE_ NN ON ( NN.SCHEMA_NAME = T1.SCHEMA_NAME AND NN.TABLE_OID = T1.TABLE_OID AND NN.TABLE_NAME = T1.TABLE_NAME AND NN.STORAGE_GRANULARITY = 1 )
      WHERE ( CURRENT_USER = 'SYSTEM'
         OR HASSYSTEMPRIVILEGE (CURRENT_USER
          , 'CATALOG READ') = 1
         OR HASSYSTEMPRIVILEGE (CURRENT_USER
          , 'DATA ADMIN') = 1
         OR CURRENT_USER = T1.SCHEMA_NAME
         OR T1.SCHEMA_NAME IN (SELECT S.SCHEMA_NAME FROM SYS._SYS_SCHEMAS_WITH_PRIVILEGES_ON S)
         OR (T1.TABLE_OID
          , 'TABLE') IN (SELECT OBJ_ID
          , OBJ_TYPE FROM SYS._SYS_GRANTED_OBJECTS) )) A
UNION ALL
SELECT A.SCHEMA_NAME,
       A.TABLE_NAME,
       A.TABLE_OID,
       A.DESCRIPTION,
       NULL,
       'TRUE',
       MAP(BITAND(A.TABLE_TYPE, 1), 1, 'TRUE', 'FALSE'),
       'FALSE',
       MAP(A.TABLE_TYPE, 33826, 'HYBRID EXTENDED', 33824, 'EXTENDED', 'VIRTUAL'),
       MAP(BITAND(A.TABLE_TYPE, 1024), 1024, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_TYPE, 512), 512, 'TRUE', 'FALSE'),
       'FALSE',
       CAST('NONE' AS VARCHAR(7)),
       CASE BITAND(A.TABLE_TYPE, 2176)
           WHEN 128 THEN 'TRUE'
           WHEN 2048 THEN 'TRUE'
           WHEN 2176 THEN 'TRUE'
           ELSE 'FALSE' END,
       MAP(BITAND(A.TABLE_TYPE, 2176), 128, 'VOLATILE', 2176, 'LOCAL', 2048, 'GLOBAL', 'NONE'),
       CAST(MAP(BITAND(A.TABLE_TYPE, 6272), 128, 'PRESERVE', 2048, 'PRESERVE', 6144, 'DELETE', NULL) AS VARCHAR(8)),
       MAP(BITAND(A.TABLE_TYPE, 8192), 8192, 'TRUE', 'FALSE'),
       CASE A.CONSTRAINT WHEN 6 THEN 'TRUE' WHEN 7 THEN 'TRUE' WHEN 15 THEN 'TRUE' WHEN 16 THEN 'TRUE' ELSE 'FALSE' END,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       NULL,
       CASE LOCATE(A.TABLE_NAME, '_SYS_REP_')
           WHEN 1 THEN 'TRUE'
           ELSE MAP(BITAND(A.TABLE_TYPE, 131072), 131072, 'TRUE', 'FALSE') END,
       'FALSE'                       HAS_STRUCTURED_PRIVILEGE_CHECK,
       CASE
           WHEN EXISTS(SELECT TABLE_OID FROM SYS.SERIES_DATA_ SD WHERE SD.TABLE_OID = A.TABLE_OID) THEN 'TRUE'
           ELSE 'FALSE' END,
       NULL,
       CREATE_TIME,
       CAST(NULL AS VARCHAR(8)) as   TEMPORAL_TYPE,
       'FALSE'                       HAS_MASKED_COLUMNS,
       NULL,
       MAP(BITAND(A.TABLE_TYPE, 1048576), 1048576, 'TRUE', 'FALSE'),
       MAP(BITAND(A.TABLE_TYPE, 2097152), 2097152, 'TRUE', 'FALSE'),
       NULL,
       'FALSE'                       IS_MOVABLE,
       CAST('DEFAULT' AS VARCHAR(7)) LOAD_UNIT
FROM (SELECT T1.SCHEMA_NAME SCHEMA_NAME,
             T1.TABLE_NAME  TABLE_NAME,
             T1.TABLE_OID   TABLE_OID,
             T1.DESCRIPTION DESCRIPTION,
             T1.TABLE_TYPE  TABLE_TYPE,
             I.CONSTRAINT CONSTRAINT, T1.CREATE_TIME CREATE_TIME
      FROM SYS.VIRTUAL_TABLES_ T1 LEFT OUTER JOIN SYS.P_INDEXES_ I
      ON ( T1.SCHEMA_NAME = I.SCHEMA AND T1.TABLE_OID = I.CID AND I.CSTABLE = 0 AND I.CONSTRAINT IN (6, 7, 15, 16) )
      WHERE ( CURRENT_USER = 'SYSTEM'
         OR HASSYSTEMPRIVILEGE (CURRENT_USER
          , 'CATALOG READ') = 1
         OR HASSYSTEMPRIVILEGE (CURRENT_USER
          , 'DATA ADMIN') = 1
         OR CURRENT_USER = T1.SCHEMA_NAME
         OR T1.SCHEMA_NAME IN (SELECT S.SCHEMA_NAME FROM SYS._SYS_SCHEMAS_WITH_PRIVILEGES_ON S)
         OR (T1.TABLE_OID
          , 'TABLE') IN (SELECT OBJ_ID
          , OBJ_TYPE FROM SYS._SYS_GRANTED_OBJECTS) )) A
```

[QP-2127]: https://chequer.atlassian.net/browse/QP-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ