### PR TITLE
QP-2363 [QSI] select 쿼리 실행시 Query results do not match pre executed results 오류 발생 (jobis)

### DIFF
--- a/Qsi.Debugger/Vendor/MySql/MySqlRepositoryProvider.cs
+++ b/Qsi.Debugger/Vendor/MySql/MySqlRepositoryProvider.cs
@@ -50,6 +50,20 @@ namespace Qsi.Debugger.Vendor.MySql
                     csMemoView.Type = QsiTableType.View;
                     AddColumns(csMemoView, "a", "b");
                     return csMemoView;
+                
+                case "hidden_test":
+                    var hiddenTest = CreateTable("sakila", "hidden_test");
+                    AddColumns(hiddenTest, "col1", "hidden1", "col2", "hidden2");
+                    hiddenTest.Columns[1].IsVisible = false;
+                    hiddenTest.Columns[3].IsVisible = false;
+                    return hiddenTest;
+                
+                case "hidden_test2":
+                    var hiddenTest2 = CreateTable("sakila", "hidden_test2");
+                    AddColumns(hiddenTest2, "col1", "col2", "hidden1", "hidden2");
+                    hiddenTest2.Columns[2].IsVisible = false;
+                    hiddenTest2.Columns[3].IsVisible = false;
+                    return hiddenTest2;
             }
 
             return null;

--- a/Qsi.MySql/Tree/Visitors/TableVisitor.cs
+++ b/Qsi.MySql/Tree/Visitors/TableVisitor.cs
@@ -445,7 +445,7 @@ namespace Qsi.MySql.Tree
 
             var derivedTableNode = new QsiDerivedTableNode();
 
-            derivedTableNode.Columns.SetValue(TreeHelper.CreateAllColumnsDeclaration());
+            derivedTableNode.Columns.SetValue(TreeHelper.CreateAllColumnsDeclaration(true));
             derivedTableNode.Source.SetValue(tableReferenceNode);
             derivedTableNode.Alias.SetValue(VisitTableAlias(alias));
 

--- a/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
+++ b/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
@@ -562,8 +562,8 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
         foreach (var pivot in pivots ?? Enumerable.Empty<IQsiColumnReferenceNode>())
         {
             var pivotColumnName = pivot.Name[^1];
-            var leftColumnIndexes = left.Columns.AllIndexOf(c => c.IsVisible && Match(c.Name, pivotColumnName)).Take(2).ToArray();
-            var rightColumnIndexes = right.Columns.AllIndexOf(c => c.IsVisible && Match(c.Name, pivotColumnName)).Take(2).ToArray();
+            var leftColumnIndexes = left.Columns.AllIndexOf(c => Match(c.Name, pivotColumnName)).Take(2).ToArray();
+            var rightColumnIndexes = right.Columns.AllIndexOf(c => Match(c.Name, pivotColumnName)).Take(2).ToArray();
 
             if (leftColumnIndexes.Length == 0 || rightColumnIndexes.Length == 0)
             {

--- a/Qsi/Utilities/TreeHelper.cs
+++ b/Qsi/Utilities/TreeHelper.cs
@@ -102,10 +102,13 @@ namespace Qsi.Utilities
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static QsiColumnsDeclarationNode CreateAllColumnsDeclaration()
+        public static QsiColumnsDeclarationNode CreateAllColumnsDeclaration(bool includeInvisibleColumns = false)
         {
             var columns = new QsiColumnsDeclarationNode();
-            columns.Columns.Add(new QsiAllColumnNode());
+            columns.Columns.Add(new QsiAllColumnNode
+            {
+                IncludeInvisibleColumns = includeInvisibleColumns
+            });
             return columns;
         }
 


### PR DESCRIPTION
https://chequer.atlassian.net/browse/QP-2363

1. `VisitSingleTable`에서 WildCard를 사용하는 경우, invisibleColumn을 제외하도록 되어있었습니다.
    invisibleColumn 또한 가져올 수 있도록 수정합니다.
2. JoinedTableAnalyzer에서 pivotColumn을 체크할 때, InvisibleColumn은 제외하고 체크하도록 되어있습니다.
    InvisibleColumn 또한 pivotcolumn으로 체크할 수 있도록 수정합니다.

테스트들은 Jira 댓글에서 확인하실 수 있으며, 엔진 코드에 DebugQSI를 통해 로컬 qsi로 테스트했을 때 모두 이상 없었습니다.