### PR TITLE
[QP-2303] Add HasIndex to QsiTableColumn

### DIFF
--- a/Qsi/Data/Table/QsiTableColumn.cs
+++ b/Qsi/Data/Table/QsiTableColumn.cs
@@ -21,6 +21,8 @@ namespace Qsi.Data
 
         public bool IsBinding { get; set; }
 
+        public bool HasIndex { get; set; }
+
         public bool IsAnonymous => Name == null;
 
         public bool IsDynamic { get; set; }
@@ -49,6 +51,7 @@ namespace Qsi.Data
             column.Default = Default;
             column.ImplicitTableWildcardTarget = ImplicitTableWildcardTarget;
             column._isExpression = _isExpression;
+            column.HasIndex = HasIndex;
 
             return column;
         }


### PR DESCRIPTION
### Summary
RepositoryProvider의 LookupTable에서 Column이 Index를 가지고 있는지 반환 할 수 있도록, HasIndex property를 추가합니다.


### Issue
https://chequer.atlassian.net/browse/QP-2303