### PR TITLE
QD-184 Bump PgQuery.Net to 1.0.5

### DIFF
--- a/Qsi.PostgreSql/Qsi.PostgreSql.csproj
+++ b/Qsi.PostgreSql/Qsi.PostgreSql.csproj
@@ -19,7 +19,7 @@
 
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="PgQuery.Net" Version="1.0.3" />
+        <PackageReference Include="PgQuery.Net" Version="1.0.5" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Native Library 경로 문제 및 Alpine 관련 문제가 있던 PgQuery.Net을 수정한 버전을 머지합니다.