### PR TITLE
Bump PgQuery.Net to 1.0.6

### DIFF
--- a/Qsi.Debugger/Packages.props
+++ b/Qsi.Debugger/Packages.props
@@ -9,7 +9,7 @@
 
     <PropertyGroup Label="Constants">
         <ChakraCoreVersion>3.5.6</ChakraCoreVersion>
-        <PgQueryVersion>4.2.1-15</PgQueryVersion>
+        <PgQueryVersion>4.2.2-15</PgQueryVersion>
     </PropertyGroup>
 
     <Choose>

--- a/Qsi.PostgreSql/PostgreSqlParser.cs
+++ b/Qsi.PostgreSql/PostgreSqlParser.cs
@@ -23,6 +23,10 @@ namespace Qsi.PostgreSql
             {
                 parseResult = Parser.Parse(script.Script);
             }
+            catch (Exception e) when (e is ArgumentNullException or DllNotFoundException or BadImageFormatException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
                 throw new QsiException(QsiError.SyntaxError, e.Message);

--- a/Qsi.PostgreSql/Qsi.PostgreSql.csproj
+++ b/Qsi.PostgreSql/Qsi.PostgreSql.csproj
@@ -19,7 +19,7 @@
 
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="PgQuery.Net" Version="1.0.5" />
+        <PackageReference Include="PgQuery.Net" Version="1.0.6" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Native Library 로드 문제가 있는 PgQuery.Net을 수정한 버전을 머지합니다.