### PR TITLE
QP-3472 Fix ConvertToExplain to get QsiExplainDataManipulationResult has SensitiveDataCollection

### DIFF
--- a/Qsi/Engines/Explain/Analyzers/ExplainActionAnalyzer.cs
+++ b/Qsi/Engines/Explain/Analyzers/ExplainActionAnalyzer.cs
@@ -70,11 +70,15 @@ namespace Qsi.Engines.Explain
                     operation |= QsiDataValueOperation.Delete;
             }
 
-            return new QsiExplainDataManipulationResult(
+            var explainResult = new QsiExplainDataManipulationResult(
                 result.Table,
                 result.AffectedColumns,
                 operations
             );
+
+            explainResult.SensitiveDataCollection.AddRange(result.SensitiveDataCollection);
+
+            return explainResult;
         }
     }
 }

--- a/Qsi/Engines/Explain/Results/QsiExplainDataManipulationResult.cs
+++ b/Qsi/Engines/Explain/Results/QsiExplainDataManipulationResult.cs
@@ -11,7 +11,7 @@ namespace Qsi.Engines.Explain
 
         public QsiDataValueOperation[] Operations { get; }
 
-        public QsiSensitiveDataCollection SensitiveDataCollection => QsiSensitiveDataCollection.Empty;
+        public QsiSensitiveDataCollection SensitiveDataCollection { get; } = new();
 
         public QsiExplainDataManipulationResult(QsiTableStructure table, QsiTableColumn[] affectedColumns, QsiDataValueOperation[] operations)
         {


### PR DESCRIPTION
QsiEngine.ExplainAsync를 사용할 경우 QsiExplainDataManipulationResult 으로 변환되는 과정에서 SensitiveDataCollection이 유실되는 문제를 해결합니다.