### PR TITLE
QD-1043 Impl QSI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup .NET 6
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: "6.0.x"
+
       - name: Publish
         shell: pwsh
         run: pwsh ./Publish.ps1 ${{ inputs.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,12 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "corretto"
+          java-version: "17"
+
       - name: Publish
         shell: pwsh
         run: pwsh ./Publish.ps1 ${{ inputs.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup .NET 6
+      - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: "6.0.x"
+          global-json-file: global.json
 
       - name: Publish
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release QSI
+
+on:
+  workflow_dispatch:
+    inputs:
+      VERSION:
+        description: 배포 버전 (ex. 0.18.16.2)
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Publish
+        shell: pwsh
+        run: pwsh ./Publish.ps1 ${{ inputs.VERSION }}
+        env:
+          QSI_NUGET_API_KEY: ${{ secrets.QSI_NUGET_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, querypie] # Nexus access required
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Publish.ps1
+++ b/Publish.ps1
@@ -26,21 +26,6 @@ if (Get-Module Antlr) {
 Import-Module ".\Build\Common.ps1"
 
 if ($_Mode -eq [PublishMode]::Publish) {
-    # git rev-parse HEAD
-    $GitTagVersion = [Version]$(git describe --tags $(git rev-list --tags --max-count=1)).trimstart('v')
-
-    if ($(git rev-parse HEAD) -ne $(git rev-parse origin/master)) {
-        throw "Publish is only allow in 'master' branch."
-    }
-
-    if ($(git diff --name-only).Length -gt 0) {
-        throw "There are files that have been changed."
-    }
-
-    if ($GitTagVersion -ge $Version) {
-        throw "The version is lower than the git tag. ($GitTagVersion >= $Version)"
-    }
-
     $NugetApiKey = $Env:QSI_NUGET_API_KEY
 
     if ($NugetApiKey.Length -eq 0) {

--- a/Publish.ps1
+++ b/Publish.ps1
@@ -157,7 +157,6 @@ if ($_Mode -eq [PublishMode]::Publish) {
 
     while ($Packages.Length -gt 0) {
         $PackageName = $Packages[0]
-        # $PackageVersion = Get-Nuget-Package-Version $Packages[0]
         if (Check-Nuget-Package-Index $PackageName $Version) {
             Write-Host "NuGet package $PackageName $Version has been indexed"
 


### PR DESCRIPTION
- QSI를 jenkins 대신 github workflow를 통해 빌드/배포 하도록 변경
  - Setup .NET
  - Setup Java
- Git version and branch protection 제거
- QSI 배포 후, Nuget 인덱싱을 기다리는 과정에서 구버전을 배포한 경우 무한 대기 현상이 발생하지 않도록 변경