### PR TITLE
QD-1323 Separate QsiTableDefinitionResult from QsiTableResult

### DIFF
--- a/Qsi/Analyzers/Definition/QsiTableDefinitionResult.cs
+++ b/Qsi/Analyzers/Definition/QsiTableDefinitionResult.cs
@@ -1,14 +1,18 @@
-using Qsi.Analyzers.Table;
 using Qsi.Data;
 
 namespace Qsi.Analyzers.Definition;
 
-public sealed class QsiTableDefinitionResult : QsiTableResult
+public sealed class QsiTableDefinitionResult : IQsiAnalysisResult
 {
     public QsiQualifiedIdentifier Name { get; }
 
-    public QsiTableDefinitionResult(QsiQualifiedIdentifier name, QsiTableStructure table) : base(table)
+    public QsiTableStructure Table { get; }
+
+    public QsiSensitiveDataCollection SensitiveDataCollection => QsiSensitiveDataCollection.Empty;
+
+    public QsiTableDefinitionResult(QsiQualifiedIdentifier name, QsiTableStructure table)
     {
         Name = name;
+        Table = table;
     }
 }


### PR DESCRIPTION
Create View의 결과인 QsiTableDefinitionResult를 QsiTableResult에서 분리하고 IQsiAnalysisResult를 구현하도록 변경합니다.

Issue Link: https://chequer.atlassian.net/browse/QD-1323