### PR TITLE
QP-4349 Fix MySQL grant RoleOrPrivilegesList NRE

### DIFF
--- a/Qsi.MySql/Tree/Visitors/ActionVisitor.cs
+++ b/Qsi.MySql/Tree/Visitors/ActionVisitor.cs
@@ -315,7 +315,7 @@ internal static class ActionVisitor
 
         if (context.roleOrPrivilegesList() is { } roleOrPrivilegesList)
         {
-            node.Roles.AddRange(roleOrPrivilegesList.roleOrPrivilege().Select(p => p.GetInputText()));
+            node.Roles = roleOrPrivilegesList.roleOrPrivilege().Select(p => p.GetInputText()).ToArray();
         }
 
         if (context.HasToken(ALL_SYMBOL))


### PR DESCRIPTION
MySQL GRANT 구문에서 VisitGrant를 통해 roleOrPrivilegesList 부분을 탈 경우,

node.Roles (string[])에서 AddRange를 사용할 때 NRE가 발생하던 문제를 해결합니다.

Issues:

https://chequer.atlassian.net/browse/QCP-994
https://chequer.atlassian.net/browse/QP-4349
