### PR TITLE
QP-4629 Fix having clause constraint

### DIFF
--- a/Qsi.MySql/Tree/Visitors/ExpressionVisitor.cs
+++ b/Qsi.MySql/Tree/Visitors/ExpressionVisitor.cs
@@ -1585,6 +1585,16 @@ internal static class ExpressionVisitor
     }
 
     #region Having Clause
+    public static QsiGroupingExpressionNode MakeEmptyQsiGroupingExpressionNode(HavingClauseContext context)
+    {
+        return TreeHelper.Create<QsiGroupingExpressionNode>(n =>
+        {
+            n.Items.AddRange(new List<QsiExpressionNode>(0));
+
+            MySqlTree.PutContextSpan(n, context);
+        });
+    }
+
     public static QsiExpressionNode VisitHavingClause(HavingClauseContext context)
     {
         return VisitExpr(context.expr());

--- a/Qsi.MySql/Tree/Visitors/TableVisitor.cs
+++ b/Qsi.MySql/Tree/Visitors/TableVisitor.cs
@@ -700,7 +700,10 @@ internal static class TableVisitor
                     node.Grouping.SetValue(ExpressionVisitor.VisitGroupByClause(groupByClause));
                     break;
 
-                case HavingClauseContext havingClause when !node.Grouping.IsEmpty:
+                case HavingClauseContext havingClause:
+                    if (node.Grouping.IsEmpty)
+                        node.Grouping.SetValue(ExpressionVisitor.MakeEmptyQsiGroupingExpressionNode(havingClause));
+
                     node.Grouping.Value.Having.SetValue(ExpressionVisitor.VisitHavingClause(havingClause));
                     break;
 


### PR DESCRIPTION
- group by절 없이 having절을 쓸 수 없었던 전제 조건을 해제합니다.
- group by가 없는 경우 having절은 where절처럼 동작합니다.
- node.Grouping이 NPE나지 않도록 QsiGroupingExpressionNode의 Items를 초기화해줍니다.