### PR TITLE
QP-4930 QP-4966 Fix underscore charset to case insensitive

### DIFF
--- a/Qsi.MySql/Antlr/MySqlLexerInternal.g4
+++ b/Qsi.MySql/Antlr/MySqlLexerInternal.g4
@@ -1111,7 +1111,7 @@ INVALID_INPUT:
 // ** Patch by QSI
 // The underscore charset token is used to defined the repertoire of a string, though it conflicts
 // with normal identifiers, which also can start with an underscore.
-UNDERSCORE_CHARSET: '_' [a-z0-9]+ { setType(checkCharset(getText())); };
+UNDERSCORE_CHARSET: '_' [a-zA-Z0-9]+ { setType(checkCharset(getText())); };
 
 // Identifiers might start with a digit, even though it is discouraged, and may not consist entirely of digits only.
 // All keywords above are automatically excluded.


### PR DESCRIPTION
## Summary
`_utf8'a'` 구문은 정상적으로 분석되지만, `_UTF8'a'` 구문은 _UTF8 컬럼과 'a' 라는 alias로 인식되는 문제를 해결합니다.

## Issues
https://chequer.atlassian.net/browse/QP-4930
https://chequer.atlassian.net/browse/QP-4966
https://chequer.atlassian.net/browse/QCP-1132