### PR TITLE
QP-4966 Fix wrong comparison of underscore charset

### DIFF
--- a/Qsi.MySql/Internal/MySqlBaseLexer.cs
+++ b/Qsi.MySql/Internal/MySqlBaseLexer.cs
@@ -169,7 +169,7 @@ internal abstract class MySqlBaseLexer : Lexer, IMySqlRecognizerCommon
     // MySQLBaseLexer::checkCharset
     protected int checkCharset(string text)
     {
-        return Charsets.Contains(text) ? MySqlLexerInternal.UNDERSCORE_CHARSET : MySqlLexerInternal.IDENTIFIER;
+        return Charsets.Contains(text.ToLowerInvariant()) ? MySqlLexerInternal.UNDERSCORE_CHARSET : MySqlLexerInternal.IDENTIFIER;
     }
 
     // MySQLBaseLexer::emitDot


### PR DESCRIPTION
## Summary
#65 에서 해결되지 못한, MySQL undescore charset의 대소문자 문제를 해결합니다.

## Issue
https://chequer.atlassian.net/browse/QP-4966