### PR TITLE
QP-5465 QD-1962 Fix parsing window functions (LAG, LEAD, NTILE)

### DIFF
--- a/Qsi.MySql/Antlr/MySqlParserInternal.g4
+++ b/Qsi.MySql/Antlr/MySqlParserInternal.g4
@@ -2528,7 +2528,7 @@ windowFunctionCall:
         | CUME_DIST_SYMBOL
         | PERCENT_RANK_SYMBOL
     ) parentheses windowingClause
-    | NTILE_SYMBOL simpleExprWithParentheses windowingClause
+    | NTILE_SYMBOL exprWithParentheses windowingClause
     | (LEAD_SYMBOL | LAG_SYMBOL) OPEN_PAR_SYMBOL expr leadLagInfo? CLOSE_PAR_SYMBOL nullTreatment? windowingClause
     | (FIRST_VALUE_SYMBOL | LAST_VALUE_SYMBOL) exprWithParentheses nullTreatment? windowingClause
     | NTH_VALUE_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL simpleExpr CLOSE_PAR_SYMBOL (
@@ -2541,7 +2541,7 @@ windowingClause:
 ;
 
 leadLagInfo:
-    COMMA_SYMBOL (ulonglong_number | paramMarker) (COMMA_SYMBOL expr)?
+    COMMA_SYMBOL expr (COMMA_SYMBOL expr)?
 ;
 
 nullTreatment:

--- a/Qsi.MySql/Tree/Visitors/ExpressionVisitor.cs
+++ b/Qsi.MySql/Tree/Visitors/ExpressionVisitor.cs
@@ -1522,6 +1522,9 @@ internal static class ExpressionVisitor
             case LAG_SYMBOL:
                 node.Parameters.Add(VisitExpr(context.expr()));
 
+                if (context.leadLagInfo() != null)
+                    node.Parameters.Add(VisitLeadLagInfo(context.leadLagInfo()));
+
                 // nullTreatment ignored
                 break;
 
@@ -2192,5 +2195,15 @@ internal static class ExpressionVisitor
         MySqlTree.PutContextSpan(node, context);
 
         return node;
+    }
+    
+    public static QsiExpressionNode VisitLeadLagInfo(LeadLagInfoContext context)
+    {
+        return TreeHelper.Create<QsiInvokeExpressionNode>(n =>
+        {
+            n.Parameters.AddRange(context.expr().Select(VisitExpr));
+
+            MySqlTree.PutContextSpan(n, context);
+        });
     }
 }

--- a/Qsi.MySql/Tree/Visitors/ExpressionVisitor.cs
+++ b/Qsi.MySql/Tree/Visitors/ExpressionVisitor.cs
@@ -1515,7 +1515,7 @@ internal static class ExpressionVisitor
                 break;
 
             case NTILE_SYMBOL:
-                node.Parameters.Add(VisitSimpleExprWithParentheses(context.simpleExprWithParentheses()));
+                node.Parameters.Add(VisitExprWithParentheses(context.exprWithParentheses()));
                 break;
 
             case LEAD_SYMBOL:

--- a/Qsi.Tests/Vendor/MySql/MySqlTest.Data.cs
+++ b/Qsi.Tests/Vendor/MySql/MySqlTest.Data.cs
@@ -178,10 +178,12 @@ public partial class MySqlTest
     {
         // QCP-1303 : https://chequer.atlassian.net/browse/QP-5465?focusedCommentId=48962
         new("SELECT LAG(first_name, 4294967295) OVER(ORDER BY actor_id) FROM actor;"),
+        new("SELECT LAG(first_name, last_name, 4294967295) OVER(ORDER BY actor_id) FROM actor;"),
         new("SELECT LAG(first_name, IF(TRUE, 2, 1)) OVER(ORDER BY actor_id) FROM actor;"),
         new("SELECT LAG(first_name, IF(TRUE, 2, 1) + IF(FALSE, 2, 1)) OVER(ORDER BY actor_id) FROM actor;"),
         
         new("SELECT LEAD(first_name, 4294967295) OVER(ORDER BY actor_id) FROM actor;"),
+        new("SELECT LEAD(first_name, last_name, 4294967295) OVER(ORDER BY actor_id) FROM actor;"),
         new("SELECT LEAD(first_name, IF(TRUE, 2, 1)) OVER(ORDER BY actor_id) FROM actor;"),
         new("SELECT LEAD(first_name, IF(TRUE, 2, 1) + IF(FALSE, 2, 1)) OVER(ORDER BY actor_id) FROM actor;"),
         

--- a/Qsi.Tests/Vendor/MySql/MySqlTest.Data.cs
+++ b/Qsi.Tests/Vendor/MySql/MySqlTest.Data.cs
@@ -74,7 +74,8 @@ public partial class MySqlTest
         new("WITH CTE AS (SELECT 1) DELETE title, category FROM film_list WHERE FID = 1 AND (SELECT `1` FROM CTE) = 1")
     };
 
-    private static readonly TestCaseData[] Test_InferredName_TestDatas = {
+    private static readonly TestCaseData[] Test_InferredName_TestDatas =
+    {
         new("SELECT DISTINCT first_name FROM actor LIMIT 1;", new[] { "first_name" }),
         new("SELECT DISTINCT `first_name` FROM actor LIMIT 1;", new[] { "first_name" }),
         new("SELECT DISTINCT (first_name) FROM actor LIMIT 1;", new[] { "first_name" }),
@@ -85,7 +86,7 @@ public partial class MySqlTest
         new("SELECT DISTINCT ((first_name)) FROM actor LIMIT 1;", new[] { "first_name" }),
         new("SELECT DISTINCT ((`first_name`)) FROM actor LIMIT 1;", new[] { "first_name" }),
         new("SELECT DISTINCT ((`actor`.`first_name`)) FROM actor LIMIT 1;", new[] { "first_name" }),
-        new("SELECT DISTINCT ((`actor`.`first_name`)) AS A FROM actor LIMIT 1;", new [] { "A" }),
+        new("SELECT DISTINCT ((`actor`.`first_name`)) AS A FROM actor LIMIT 1;", new[] { "A" }),
         new("SELECT DISTINCT DISTINCT DISTINCT ((`actor`.`first_name`)) FROM actor LIMIT 1;", new[] { "first_name" }),
         new("SELECT DISTINCT (actor_id) FROM actor WHERE first_name = ANY(SELECT DISTINCT first_name FROM actor);", new[] { "actor_id" }),
         new("SELECT actor_id IN (1, 2, 3) FROM actor LIMIT 1", new[] { "actor_id IN (1, 2, 3)" }),
@@ -93,14 +94,14 @@ public partial class MySqlTest
         new("SELECT (`actor_id`) IN (1, 2, 3) FROM actor LIMIT 1", new[] { "(`actor_id`) IN (1, 2, 3)" }),
         new("SELECT actor_id IN (`actor_id`) FROM actor LIMIT 1", new[] { "actor_id IN (`actor_id`)" }),
         new("SELECT (actor_id IN (`actor_id`)) FROM actor LIMIT 1", new[] { "(actor_id IN (`actor_id`))" }),
-        
-        
+
+
         new("SELECT actor_id, first_name FROM actor LIMIT 1;", new[] { "actor_id", "first_name" }),
         new("SELECT `actor_id`, `first_name` FROM actor LIMIT 1;", new[] { "actor_id", "first_name" }),
         new("SELECT (actor_id), (first_name) FROM actor LIMIT 1;", new[] { "actor_id", "first_name" }),
         new("SELECT (`actor_id`), (`first_name`) FROM actor LIMIT 1;", new[] { "actor_id", "first_name" }),
         new("SELECT (`actor`.`actor_id`), (`actor`.first_name) FROM actor LIMIT 1", new[] { "actor_id", "first_name" }),
-        
+
         new("SELECT SUM(DISTINCT first_name) FROM actor LIMIT 1;", new[] { "SUM(DISTINCT first_name)" }),
         new("SELECT SUM(DISTINCT `first_name`) FROM actor LIMIT 1;", new[] { "SUM(DISTINCT `first_name`)" }),
         new("SELECT SUM(DISTINCT (first_name)) FROM actor LIMIT 1;", new[] { "SUM(DISTINCT (first_name))" }),
@@ -110,11 +111,11 @@ public partial class MySqlTest
         new("SELECT SUM(DISTINCT ((first_name))) FROM actor LIMIT 1;", new[] { "SUM(DISTINCT ((first_name)))" }),
         new("SELECT SUM(DISTINCT ((`first_name`))) FROM actor LIMIT 1;", new[] { "SUM(DISTINCT ((`first_name`)))" }),
         new("SELECT SUM(actor_id) FROM actor WHERE first_name = ANY(select DISTINCT first_name FROM actor);", new[] { "SUM(actor_id)" }),
-        
+
         new("SELECT @actor_id:=@actor_ID+1 FROM actor;", new[] { "@actor_id:=@actor_ID+1" }),
         new("SELECT ABS(LAG(rental_id, 1, rental_id) OVER (ORDER BY rental_id) - rental_id) FROM payment LIMIT 1;",
             new[] { "ABS(LAG(rental_id, 1, rental_id) OVER (ORDER BY rental_id) - rental_id)" }),
-        
+
         new("SELECT ('A' | 'B');", new[] { "('A' | 'B')" }),
         new("SELECT ('A' || 'B');", new[] { "('A' || 'B')" }),
         new("SELECT ('A' xor 'B');", new[] { "('A' xor 'B')" }),
@@ -133,12 +134,12 @@ public partial class MySqlTest
         // PredicateExprIn:         IN_SYMBOL (subquery | OPEN_PAR_SYMBOL exprList CLOSE_PAR_SYMBOL)
         new("SELECT actor_id IN (SELECT actor_id from actor) FROM actor LIMIT 1;", new[] { "actor_id IN (SELECT actor_id from actor)" }),
         new("SELECT actor_id IN (1, 2, 3) FROM actor LIMIT 1;", new[] { "actor_id IN (1, 2, 3)" }),
-        
+
         // PredicateExprBetween:    BETWEEN_SYMBOL bitExpr AND_SYMBOL predicate
         new("SELECT actor_id BETWEEN 1 AND 3 FROM actor LIMIT 1;", new[] { "actor_id BETWEEN 1 AND 3" }),
         new("SELECT actor_id BETWEEN (1) AND (3) FROM actor LIMIT 1;", new[] { "actor_id BETWEEN (1) AND (3)" }),
         new("SELECT actor_id BETWEEN (SELECT actor_id FROM actor LIMIT 1) AND (3) FROM actor LIMIT 1;", new[] { "actor_id BETWEEN (SELECT actor_id FROM actor LIMIT 1) AND (3)" }),
-        
+
         // PredicateExprLike:       LIKE_SYMBOL simpleExpr (ESCAPE_SYMBOL simpleExpr)?
         new("SELECT first_name LIKE '%A%' FROM actor LIMIT 1;", new[] { "first_name LIKE '%A%'" }),
         new("SELECT first_name LIKE ('%A%' OR '%B%') FROM actor LIMIT 1;", new[] { "first_name LIKE ('%A%' OR '%B%')" }),
@@ -163,7 +164,7 @@ public partial class MySqlTest
         // NOTE: Table must descript FULLTEXT indexing.
         // FULLTEXT SEARCH do not affect to search result columns naming.
         // new("SELECT * FROM actor WHERE MATCH(last_name) AGAINST('GUINESS');", new[] { "" }),
-        
+
         new("SELECT * FROM actor LIMIT 1;", new[] { "actor_id", "first_name", "last_name", "last_update" }),
         new("SELECT * FROM actor a INNER JOIN actor_info ai USING (actor_id) LIMIT 1;", new[] { "actor_id", "first_name", "last_name", "last_update", "first_name", "last_name", "film_info" }),
         new("SELECT actor_id FROM actor a INNER JOIN actor_info ai USING (actor_id) LIMIT 1;", new[] { "actor_id" }),
@@ -171,5 +172,21 @@ public partial class MySqlTest
         new("SELECT f.title, fl.title FROM film AS f JOIN film_list AS fl LIMIT 1;", new[] { "title", "title" }),
         new("SELECT (f.title), (fl.title) FROM film AS f JOIN film_list AS fl LIMIT 1;", new[] { "title", "title" }),
         new("SELECT DISTINCT (f.title), (fl.title) FROM film AS f JOIN film_list AS fl LIMIT 1;", new[] { "title", "title" }),
+    };
+
+    private static readonly TestCaseData[] Test_LeadLagInfo_TestDatas = 
+    {
+        // QCP-1303 : https://chequer.atlassian.net/browse/QP-5465?focusedCommentId=48962
+        new("SELECT LAG(first_name, 4294967295) OVER(ORDER BY actor_id) FROM actor;"),
+        new("SELECT LAG(first_name, IF(TRUE, 2, 1)) OVER(ORDER BY actor_id) FROM actor;"),
+        new("SELECT LAG(first_name, IF(TRUE, 2, 1) + IF(FALSE, 2, 1)) OVER(ORDER BY actor_id) FROM actor;"),
+        
+        new("SELECT LEAD(first_name, 4294967295) OVER(ORDER BY actor_id) FROM actor;"),
+        new("SELECT LEAD(first_name, IF(TRUE, 2, 1)) OVER(ORDER BY actor_id) FROM actor;"),
+        new("SELECT LEAD(first_name, IF(TRUE, 2, 1) + IF(FALSE, 2, 1)) OVER(ORDER BY actor_id) FROM actor;"),
+        
+        new("SELECT NTILE(4294967295) OVER(ORDER BY actor_id) FROM actor;"),
+        new("SELECT NTILE(IF(TRUE, 2, 1)) OVER(ORDER BY actor_id) FROM actor;"),
+        new("SELECT NTILE(IF(TRUE, 2, 1) + IF(FALSE, 2, 1)) OVER(ORDER BY actor_id) FROM actor;")
     };
 }

--- a/Qsi.Tests/Vendor/MySql/MySqlTest.cs
+++ b/Qsi.Tests/Vendor/MySql/MySqlTest.cs
@@ -238,5 +238,6 @@ public partial class MySqlTest : VendorTestBase
     public async Task Test_LeadLagInfo(string sql)
     {
         Assert.DoesNotThrowAsync
-            (() => Engine.Execute(new QsiScript(sql, QsiScriptType.Select), null).AsTask()); }
+            (() => Engine.Execute(new QsiScript(sql, QsiScriptType.Select), null).AsTask());
+    }
 }

--- a/Qsi.Tests/Vendor/MySql/MySqlTest.cs
+++ b/Qsi.Tests/Vendor/MySql/MySqlTest.cs
@@ -233,4 +233,10 @@ public partial class MySqlTest : VendorTestBase
 
         Assert.AreEqual(expectColumnNames, qsiIdentifierColumnNames);
     }
+
+    [TestCaseSource(nameof(Test_LeadLagInfo_TestDatas))]
+    public async Task Test_LeadLagInfo(string sql)
+    {
+        Assert.DoesNotThrowAsync
+            (() => Engine.Execute(new QsiScript(sql, QsiScriptType.Select), null).AsTask()); }
 }


### PR DESCRIPTION
### What is this PR? 🔍
[MySQL 8.0.22 버전부터 LEAD, LAG, NTILE 함수의 인자로 다음과 같은 인자를 받을 수 있도록 변경](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-22.html#mysqld-8-0-22-optimizer)되었습니다. 

> Beginning with MySQL 8.0.22, N cannot be NULL. In addition, it must now be an integer in the range 0 to 2^63, inclusive, in any of the following forms:
> 
> an unsigned integer constant literal
> 
> a positional parameter marker(?)
> 
> a user-defined variable
> 
> a local variable in a stored routine

```
LAG(expr [, N[, default]]) [null_treatment] over_clause

LEAD(expr [, N[, default]]) [null_treatment] over_clause

NTILE(N) over_clause
```

따라서 [MySqlParserInternal.g4](https://github.com/chequer-io/qsi/blob/main/Qsi.MySql/Antlr/MySqlParserInternal.g4)의 [leadLagInfo](https://github.com/chequer-io/qsi/blob/main/Qsi.MySql/Antlr/MySqlParserInternal.g4#L2543)에서도 인자의 범위를 확대하였습니다.

### Issue 📌
- [https://chequer.atlassian.net/browse/QCP-1303](https://chequer.atlassian.net/browse/QCP-1303)
- [https://chequer.atlassian.net/browse/QP-5465](https://chequer.atlassian.net/browse/QP-5465)