### PR TITLE
Add thread-safety to AcornParser methods

### DIFF
--- a/Qsi.MongoDB/Acorn/AcornParser.cs
+++ b/Qsi.MongoDB/Acorn/AcornParser.cs
@@ -16,6 +16,7 @@ internal static class AcornParser
 {
     private static readonly JavascriptContext _javascriptContext;
     private static readonly JsonSerializerSettings _serializerSettings;
+    private static readonly object _lockObj = new();
 
     static AcornParser()
     {
@@ -103,18 +104,27 @@ internal static class AcornParser
 
     public static string Execute(string code)
     {
-        return _javascriptContext.Evaluate(code);
+        lock (_lockObj)
+        {
+            return _javascriptContext.Evaluate(code);
+        }
     }
 
     internal static string ParseStrict(string code)
     {
-        _javascriptContext.SetVariable("code", code);
-        return _javascriptContext.Evaluate($"JSON.stringify(acorn.parse(code, {{locations: true}}))");
+        lock (_lockObj)
+        {
+            _javascriptContext.SetVariable("code", code);
+            return _javascriptContext.Evaluate("JSON.stringify(acorn.parse(code, {{locations: true}}))");
+        }
     }
 
     internal static string ParseLoose(string code)
     {
-        _javascriptContext.SetVariable("code", code);
-        return _javascriptContext.Evaluate($"JSON.stringify(acorn.loose.LooseParser.parse(code, {{locations: true}}))");
+        lock (_lockObj)
+        {
+            _javascriptContext.SetVariable("code", code);
+            return _javascriptContext.Evaluate("JSON.stringify(acorn.loose.LooseParser.parse(code, {{locations: true}}))");
+        }
     }
 }


### PR DESCRIPTION
## What is this PR? 🔍
AcornParser 클래스 내의 Execute, ParseStrict, ParseLoose 메소드가 동시에 실행되면 예상치 못한 오류 상황들이 발생합니다. 이 상황을 방지하도록 lock 객체를 사용하여 문제를 방지합니다.

## Changes 📝
- AcornParser의 Execute, ParseStrict, ParseLoose 함수에 lock 구문으로 감쌉니다.
