### PR TITLE
[QP-7661] PostgreSQL에서 Insert Action의 대상 컬럼 Resolve 메소드 오버라이드

### DIFF
--- a/Qsi.PostgreSql/Analyzers/PgActionAnalyzer.cs
+++ b/Qsi.PostgreSql/Analyzers/PgActionAnalyzer.cs
@@ -1,0 +1,36 @@
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using Qsi.Analyzers.Action;
+using Qsi.Analyzers.Action.Context;
+using Qsi.Analyzers.Action.Models;
+using Qsi.Analyzers.Context;
+using Qsi.Data;
+using Qsi.Engines;
+using Qsi.PostgreSql.Tree.Nodes;
+using Qsi.Tree;
+using Qsi.Utilities;
+
+namespace Qsi.PostgreSql.Analyzers;
+
+public class PgActionAnalyzer : QsiActionAnalyzer
+{
+    public PgActionAnalyzer(QsiEngine engine) : base(engine)
+    {
+    }
+
+    protected override ColumnTarget[] ResolveColumnTargetsFromDataInsertAction(IAnalyzerContext context, QsiTableStructure table, IQsiDataInsertActionNode action)
+    {
+        if (!ListUtility.IsNullOrEmpty(action.Columns) || !ListUtility.IsNullOrEmpty(action.SetValues))
+            return base.ResolveColumnTargetsFromDataInsertAction(context, table, action);
+
+        return ResolveColumnTargetsFromTable(context, table, (PgDerivedTableNode)action.ValueTable);
+    }
+
+    protected ColumnTarget[] ResolveColumnTargetsFromTable(IAnalyzerContext context, QsiTableStructure table, PgDerivedTableNode valueTable)
+    {
+        return ResolveColumnTargetsFromTable(context, table)
+            .Take(valueTable.Columns.Value.Count)
+            .ToArray();
+    }
+}

--- a/Qsi.PostgreSql/PostgreSqlLanguageServiceBase.cs
+++ b/Qsi.PostgreSql/PostgreSqlLanguageServiceBase.cs
@@ -40,7 +40,7 @@ public abstract class PostgreSqlLanguageServiceBase : QsiLanguageServiceBase
 
     public override IEnumerable<IQsiAnalyzer> CreateAnalyzers(QsiEngine engine)
     {
-        yield return new QsiActionAnalyzer(engine);
+        yield return new PgActionAnalyzer(engine);
         yield return new PgTableAnalyzer(engine);
         yield return new QsiDefinitionAnalyzer(engine);
     }

--- a/Qsi.PrimarSql/Analyzers/PrimarSqlActionAnalyzer.cs
+++ b/Qsi.PrimarSql/Analyzers/PrimarSqlActionAnalyzer.cs
@@ -162,7 +162,7 @@ public class PrimarSqlActionAnalyzer : QsiActionAnalyzer
 
         var table = await tableAnalyzer.BuildTableStructure(tableContext, action.Target);
 
-        ColumnTarget[] columnTargets = ResolveColumnTargetsFromDataInsertAction(context, table, action);
+        ColumnTarget[] columnTargets = await ResolveColumnTargetsFromDataInsertActionAsync(context, table, action);
         var insertRows = new QsiDataRowCollection(columnTargets.Length, context.Engine.CacheProviderFactory());
 
         foreach (var value in action.Values)
@@ -197,7 +197,7 @@ public class PrimarSqlActionAnalyzer : QsiActionAnalyzer
         }.ToSingleArray();
     }
 
-    protected override ColumnTarget[] ResolveColumnTargetsFromDataInsertAction(IAnalyzerContext context, QsiTableStructure table, IQsiDataInsertActionNode action)
+    protected override ValueTask<ColumnTarget[]> ResolveColumnTargetsFromDataInsertActionAsync(IAnalyzerContext context, QsiTableStructure table, IQsiDataInsertActionNode action)
     {
         // table.Columns[0] : hash (required)
         // table.Columns[1] : sort (optional)
@@ -271,7 +271,7 @@ public class PrimarSqlActionAnalyzer : QsiActionAnalyzer
             }
         }
 
-        return targets;
+        return ValueTask.FromResult(targets);
     }
 
     private Exception CreateColumnsNotSpecifiedError(IReadOnlyList<QsiTableColumn> notSpecifiedColumns)

--- a/Qsi/Analyzers/Action/QsiActionAnalyzer.cs
+++ b/Qsi/Analyzers/Action/QsiActionAnalyzer.cs
@@ -465,7 +465,7 @@ public class QsiActionAnalyzer : QsiAnalyzerBase
             table = (await tableAnalyzer.BuildTableStructure(tableContext, action.Target)).CloneVisibleOnly();
         }
 
-        ColumnTarget[] columnTargets = ResolveColumnTargetsFromDataInsertAction(context, table, action);
+        ColumnTarget[] columnTargets = await ResolveColumnTargetsFromDataInsertActionAsync(context, table, action);
 
         var dataContext = new TableDataInsertContext(context, table)
         {
@@ -506,15 +506,26 @@ public class QsiActionAnalyzer : QsiAnalyzerBase
             .ToArray<IQsiAnalysisResult>();
     }
 
-    protected virtual ColumnTarget[] ResolveColumnTargetsFromDataInsertAction(IAnalyzerContext context, QsiTableStructure table, IQsiDataInsertActionNode action)
+    protected virtual ValueTask<ColumnTarget[]> ResolveColumnTargetsFromDataInsertActionAsync(IAnalyzerContext context, QsiTableStructure table, IQsiDataInsertActionNode action)
     {
-        if (!ListUtility.IsNullOrEmpty(action.Columns))
-            return ResolveColumnTargetsFromIdentifiers(context, table, action.Columns);
+        ColumnTarget[] columnTargets;
 
-        if (!ListUtility.IsNullOrEmpty(action.SetValues))
-            return ResolveSetColumnTargets(context, table, action.SetValues).ToArray<ColumnTarget>();
+        switch (action)
+        {
+            case { Columns.Length: > 0 }:
+                columnTargets = ResolveColumnTargetsFromIdentifiers(context, table, action.Columns);
+                break;
 
-        return ResolveColumnTargetsFromTable(context, table);
+            case { SetValues.Length: > 0 }:
+                columnTargets = ResolveSetColumnTargets(context, table, action.SetValues).ToArray<ColumnTarget>();
+                break;
+
+            default:
+                columnTargets = ResolveColumnTargetsFromTable(context, table);
+                break;
+        }
+
+        return ValueTask.FromResult(columnTargets);
     }
 
     protected virtual ColumnTarget[] ResolveColumnTargetsFromIdentifiers(IAnalyzerContext context, QsiTableStructure table, IEnumerable<QsiQualifiedIdentifier> identifiers)


### PR DESCRIPTION
## What is this PR? 🔍

`INSERT INTO [테이블] [SELECT 쿼리]` 구문의 경우 PostgreSQL에서는 테이블의 컬럼 수와 쿼리의 컬럼 수가 다르더라도 (테이블의 앞쪽 컬럼부터 SELECT 쿼리의 결과값들을 순서대로 채워서) 삽입을 받아들이지만, QSI에서는  resolve한 target column의 수가 query의 컬럼 수와 다른 경우 벤더 구분 없이 `QSI-000F: The used Statements have a different number of columns.` 에러를 일으킵니다. 

이 PR은 PostgreSQL의 경우 target column을 resolve 하는 메소드를 override해서 target column을 query의 컬럼 개수만큼만 resolve 하도록 해 이 에러를 피합니다.

## Issue 📌

https://chequer.atlassian.net/browse/QP-7661