### PR TITLE
QP-7992 Fix Not supported serialization type: Qsi.MySql.Data.MySqlString

### DIFF
--- a/Qsi.MySql/Analyzers/MySqlActionAnalyzer.cs
+++ b/Qsi.MySql/Analyzers/MySqlActionAnalyzer.cs
@@ -7,6 +7,7 @@ using Qsi.Analyzers.Context;
 using Qsi.Data;
 using Qsi.Engines;
 using Qsi.Extensions;
+using Qsi.MySql.Data;
 using Qsi.MySql.Tree;
 using Qsi.Tree;
 using static Qsi.MySql.Tree.MySqlProperties;
@@ -47,6 +48,16 @@ public class MySqlActionAnalyzer : QsiActionAnalyzer
         }
 
         return result;
+    }
+
+    protected override QsiDataValue ResolveColumnValue(IAnalyzerContext context, IQsiExpressionNode expression)
+    {
+        if (expression is IQsiLiteralExpressionNode { Value: MySqlString mysqlString })
+        {
+            return new QsiDataValue(mysqlString.ToString(), QsiDataType.String);
+        }
+
+        return base.ResolveColumnValue(context, expression);
     }
 
     protected override QsiVariableSetActionResult ResolveVariableSet(IAnalyzerContext context, IQsiVariableSetItemNode node)

--- a/Qsi/Analyzers/Action/QsiActionAnalyzer.cs
+++ b/Qsi/Analyzers/Action/QsiActionAnalyzer.cs
@@ -147,7 +147,7 @@ public class QsiActionAnalyzer : QsiAnalyzerBase
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    protected QsiDataValue ResolveColumnValue(IAnalyzerContext context, IQsiExpressionNode expression)
+    protected virtual QsiDataValue ResolveColumnValue(IAnalyzerContext context, IQsiExpressionNode expression)
     {
         switch (expression)
         {


### PR DESCRIPTION
## Summary
BLOB에 대한 DML Snapshot의 BeforeRows, AfterRows Value가 MySqlString으로 Resolve되는 문제를 해결합니다.

## Issue
https://chequer.atlassian.net/browse/QP-7992