### PR TITLE
[QP-8003] Insert Action에서 Not Null 제약조건 있는 컬럼에 값 지정 없을 시 에러 처리

### DIFF
--- a/Qsi.Tests/Vendor/PostgreSql/Driver/PostgreSqlRepositoryProvider.cs
+++ b/Qsi.Tests/Vendor/PostgreSql/Driver/PostgreSqlRepositoryProvider.cs
@@ -89,7 +89,7 @@ order by ORDINAL_POSITION";
                 var column = table.NewColumn();
                 column.Name = new QsiIdentifier(reader.GetString(0), false);
                 column.IsNullable = reader.GetString(1) == "YES";
-                column.Default = reader.GetString(2);
+                column.Default = reader.IsDBNull(2) ? null : reader.GetString(2);
             }
         }
 

--- a/Qsi.Tests/Vendor/PostgreSql/Driver/PostgreSqlRepositoryProvider.cs
+++ b/Qsi.Tests/Vendor/PostgreSql/Driver/PostgreSqlRepositoryProvider.cs
@@ -7,6 +7,7 @@ using Qsi.Data;
 using Qsi.Data.Object;
 using Qsi.Data.Object.Function;
 using Qsi.Engines;
+using Qsi.PostgreSql.Data;
 using Qsi.Utilities;
 
 namespace Qsi.Tests.PostgreSql.Driver;
@@ -76,7 +77,7 @@ limit 1";
         }
 
         sql = $@"
-select COLUMN_NAME 
+select COLUMN_NAME, IS_NULLABLE, COLUMN_DEFAULT
 from information_schema.COLUMNS
 where TABLE_CATALOG = '{table.Identifier[0]}' and TABLE_SCHEMA = '{table.Identifier[1].Value}' and TABLE_NAME = '{table.Identifier[2].Value}'
 order by ORDINAL_POSITION";
@@ -87,6 +88,8 @@ order by ORDINAL_POSITION";
             {
                 var column = table.NewColumn();
                 column.Name = new QsiIdentifier(reader.GetString(0), false);
+                column.IsNullable = reader.GetString(1) == "YES";
+                column.Default = reader.GetString(2);
             }
         }
 

--- a/Qsi.Tests/Vendor/PostgreSql/PostgreSqlTest.cs
+++ b/Qsi.Tests/Vendor/PostgreSql/PostgreSqlTest.cs
@@ -275,6 +275,38 @@ public partial class PostgreSqlTest : VendorTestBase
     }
 
     /// <summary>
+    /// Insert Action 시 Not Null 제약조건 있는 테이블에 값 대입하는 상황에 관한 에러 처리를 확인하는 테스트를 수행합니다.
+    /// </summary>
+    [Test]
+    public async Task Test_InsertNotNull()
+    {
+        const string CreateTableQuery = @"create table if not exists test_not_null (
+col1 VARCHAR NOT NULL,
+col2 VARCHAR
+)";
+
+        var command = Connection.CreateCommand();
+        command.CommandText = CreateTableQuery;
+        await command.ExecuteNonQueryAsync();
+
+        string[] queries =
+        {
+            "INSERT INTO test_not_null VALUES (null, 'test')",
+            "INSERT INTO test_not_null (col2) VALUES ('test')"
+        };
+
+        const string errorMessage = "QSI-0021: The column 'col1' has a Not Null constraint.";
+
+        foreach (var query in queries)
+        {
+            Assert.ThrowsAsync<QsiException>(async () =>
+            {
+                await Engine.Execute(new QsiScript(query, QsiScriptType.Insert), null);
+            }, errorMessage);
+        }
+    }
+
+    /// <summary>
     /// Parameterized query에 대하여 테스트를 수행합니다.
     /// </summary>
     /// <param name="query">Parameterized된 쿼리입니다.</param>

--- a/Qsi/Data/Table/QsiTableColumn.cs
+++ b/Qsi/Data/Table/QsiTableColumn.cs
@@ -35,6 +35,8 @@ public class QsiTableColumn
         set => _isExpression = value;
     }
 
+    public bool IsNullable { get; set; } = true;
+
     internal QsiQualifiedIdentifier ImplicitTableWildcardTarget { get; set; }
 
     internal bool _isExpression;
@@ -52,6 +54,7 @@ public class QsiTableColumn
         column.ImplicitTableWildcardTarget = ImplicitTableWildcardTarget;
         column._isExpression = _isExpression;
         column.HasIndex = HasIndex;
+        column.IsNullable = IsNullable;
 
         return column;
     }

--- a/Qsi/QsiError.cs
+++ b/Qsi/QsiError.cs
@@ -73,7 +73,7 @@ internal static class SR
     public const string InvalidNestedExplain = "Invalid nested explain for '{0}'";
     public const string SubqueryReturnsMoreThanRow = "Subquery returns more than {0} row";
     public const string UnableResolveFunction = "Unable to resolve function '{0}'";
-    public const string NotNullConstraints = "Not Null constraints violation.";
+    public const string NotNullConstraints = "The column '{0}' has a Not Null constraint.";
 
     public static string GetResource(QsiError error)
     {

--- a/Qsi/QsiError.cs
+++ b/Qsi/QsiError.cs
@@ -34,7 +34,8 @@ public enum QsiError
     ParameterNotFound,
     InvalidNestedExplain,
     SubqueryReturnsMoreThanRow,
-    UnableResolveFunction
+    UnableResolveFunction,
+    NotNullConstraints
 }
 
 internal static class SR
@@ -72,6 +73,7 @@ internal static class SR
     public const string InvalidNestedExplain = "Invalid nested explain for '{0}'";
     public const string SubqueryReturnsMoreThanRow = "Subquery returns more than {0} row";
     public const string UnableResolveFunction = "Unable to resolve function '{0}'";
+    public const string NotNullConstraints = "Not Null constraints violation.";
 
     public static string GetResource(QsiError error)
     {
@@ -110,6 +112,7 @@ internal static class SR
             QsiError.InvalidNestedExplain => InvalidNestedExplain,
             QsiError.SubqueryReturnsMoreThanRow => SubqueryReturnsMoreThanRow,
             QsiError.UnableResolveFunction => UnableResolveFunction,
+            QsiError.NotNullConstraints => NotNullConstraints,
             _ => null
         };
     }


### PR DESCRIPTION
1. Insert Action에서 Not Null 제약조건 있는 컬럼이 있음에도 그 컬럼에 Null 값을 대입한다든가, default 값이 없음에도 그 컬럼에는 값을 지정하지 않고 다른 컬럼에만 값을 대입하는 등(예를 들어, `field2`에 Not Null 제약조건 있는데도 `INSERT INTO table1 (field1) VALUES ('1')` 이런 쿼리를 입력하는데 `field2`는 default가 없는 경우 등) 상황이 발생하면 일반적인 RDBMS는 그에 관한 에러 메시지를 출력하며, QSI도 본 프로젝트의 취지상 이 상황에서 에러 메시지를 출력해야 합니다. 하지만 현재 QSI의 코드는 관련 처리가 없습니다.

2. 이 PR은 다음 변경사항을 통해 Not Null 제약조건에 관한 에러를 처리합니다.

    - `QsiTableColumn` 에 `IsNullable` 속성을 추가하고, 이 속성의 default를 `true`로 설정합니다. 에러를 일으키는 조건식은 `IsNullable`이 `false`인 상황을 전제하므로, QSI를 사용하는 프로젝트에서 `IsNullable` 속성에 값을 대입하는 코드 구현을 하지 않는다면 관련 에러가 일어나지 않습니다.

    - Insert Action 수행 전에 테이블에서 값을 대입할 대상 컬럼들을 가져온 후, `ResolveNotNullableColumnWithInvalidDefault` 메소드를 통해 테이블에서 대상 컬럼이 아닌 컬럼이 'Not Null 제약조건을 갖고 있으면서 default 값이 적절히 지정됐는지'를 검사합니다. 대상 컬럼이 아닌 컬럼 중 default 값이 지정된 바 없는데 Not Null 제약조건이 있다면 에러를 일으키도록 합니다.

    - Insert Action 수행 시, 대상 컬럼에 Null 값을 대입해야 하는 상황에서 해당 컬럼에 Not Null 제약조건이 있는 경우에 에러를 일으키도록 합니다.

3. 이 PR의 변경사항을 활용하는 사례로서, PostgreSQL 관련 사용례 테스트 코드를 추가합니다. (즉, Insert Action에서 타겟 테이블의 컬럼에 Not Null 제약조건 있으나 Null을 입력하는 경우에 에러를 일으키도록 하려면 이 프로젝트를 사용할 때 각 테이블의 컬럼이 Not Null 제약조건이 있는지 및 default 값이 있는지 여부를 조회해야 합니다.)