### PR TITLE
[QP-8036] PgTableAnalyzer 에서, 현재 찾으려는 테이블 함수가 아닌 함수 필터링 조건 변경

### DIFF
--- a/Qsi.PostgreSql/Analyzers/PgTableAnalyzer.cs
+++ b/Qsi.PostgreSql/Analyzers/PgTableAnalyzer.cs
@@ -103,8 +103,12 @@ public class PgTableAnalyzer : QsiTableAnalyzer
                         // IsSystem = true // NOTE: Is it System Table?
                     };
 
-                    if (!funcDef.ReturnType.Value.Setof && func.ArgumentsCount != invoke.Parameters.Count)
+                    if (!funcDef.ReturnType.Value.Setof &&
+                        (invoke.Parameters.Count < func.ArgumentsCount - func.DefaultArgumentsCount ||
+                         invoke.Parameters.Count > func.ArgumentsCount))
+                    {
                         continue;
+                    }
 
                     #region Special Functions
                     // pg_catalog.unnest: same return count with parameter count

--- a/Qsi.Tests/Vendor/PostgreSql/Driver/PostgreSqlRepositoryProvider.cs
+++ b/Qsi.Tests/Vendor/PostgreSql/Driver/PostgreSqlRepositoryProvider.cs
@@ -142,12 +142,12 @@ WHERE relname = '{identifier[^1]}'";
 
     protected IEnumerable<QsiFunctionObject> LookupFunction(QsiQualifiedIdentifier identifier)
     {
-        var funcInformation = @$"select oid, pronargs from ""{identifier[0]}"".pg_catalog.pg_proc
+        var funcInformation = @$"select oid, pronargs, pronargdefaults from ""{identifier[0]}"".pg_catalog.pg_proc
          where
              proname = '{identifier[2]}' and
              pronamespace = (select oid from pg_namespace where nspname = '{identifier[1]}' limit 1);";
 
-        var funcDefinitions = new List<(string, int)>();
+        var funcDefinitions = new List<(string, int, int)>();
 
         using (var reader = GetDataReaderCoreAsync(new QsiScript(funcInformation, QsiScriptType.Select), null, default).Result)
         {
@@ -155,19 +155,20 @@ WHERE relname = '{identifier[^1]}'";
             {
                 var oid = reader.GetString(0);
                 var argsCount = reader.GetString(1);
+                var defaultArgsCount = reader.GetString(2);
 
-                funcDefinitions.Add((oid, int.Parse(argsCount)));
+                funcDefinitions.Add((oid, int.Parse(argsCount), int.Parse(defaultArgsCount)));
             }
         }
 
-        foreach (var (oid, argsCount) in funcDefinitions)
+        foreach (var (oid, argsCount, defaultArgsCount) in funcDefinitions)
         {
-            using var defReader = GetDataReaderCoreAsync(new QsiScript($@"SELECT pg_catalog.pg_get_functiondef({oid})", QsiScriptType.Select), null, default).Result;
+            using var defReader = GetDataReaderCoreAsync(new QsiScript($"SELECT pg_catalog.pg_get_functiondef({oid})", QsiScriptType.Select), null, default).Result;
 
             if (!defReader.Read())
                 continue;
 
-            yield return new QsiFunctionObject(identifier, defReader.GetString(0), argsCount);
+            yield return new QsiFunctionObject(identifier, defReader.GetString(0), argsCount, defaultArgsCount);
         }
     }
 

--- a/Qsi.Tests/Vendor/PostgreSql/PostgreSqlTest.cs
+++ b/Qsi.Tests/Vendor/PostgreSql/PostgreSqlTest.cs
@@ -367,4 +367,38 @@ public partial class PostgreSqlTest : VendorTestBase
 
         Assert.Pass();
     }
+
+    /// <summary>
+    /// Default 값 설정된 인자를 갖는 함수를 테이블 함수로 인자 없이 호출하는 경우에 대해 테스트를 수행합니다.
+    /// </summary>
+    [Test]
+    public async Task Test_TableFunctionWithDefaultArgument()
+    {
+        const string CreateTableFunctionQuery = @"
+CREATE OR REPLACE FUNCTION get_department_info_for_pgtest(department_name TEXT DEFAULT 'Engineering')
+RETURNS TEXT AS $$
+BEGIN
+    RETURN department_name;
+END;
+$$ LANGUAGE plpgsql;
+";
+
+        var command = Connection.CreateCommand();
+        command.CommandText = CreateTableFunctionQuery;
+        await command.ExecuteNonQueryAsync();
+
+        string[] queries =
+        {
+            "SELECT * FROM get_department_info_for_pgtest();",
+            "SELECT * FROM get_department_info_for_pgtest('Marketing');"
+        };
+
+        foreach (var query in queries)
+        {
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                await Engine.Execute(new QsiScript(query, QsiScriptType.Select), null);
+            });
+        }
+    }
 }

--- a/Qsi/Data/Object/Function/QsiFunctionObject.cs
+++ b/Qsi/Data/Object/Function/QsiFunctionObject.cs
@@ -6,11 +6,19 @@ public class QsiFunctionObject : QsiObject
 
     public string Definition { get; }
 
-    public int ArgumentsCount { get; } 
-    
+    public int ArgumentsCount { get; }
+
+    public int DefaultArgumentsCount { get; }
+
     public QsiFunctionObject(QsiQualifiedIdentifier identifier, string definition, int argumentsCount) : base(identifier)
     {
         Definition = definition;
         ArgumentsCount = argumentsCount;
+    }
+
+    public QsiFunctionObject(QsiQualifiedIdentifier identifier, string definition, int argumentsCount, int defaultArgumentsCount)
+        : this(identifier, definition, argumentsCount)
+    {
+        DefaultArgumentsCount = defaultArgumentsCount;
     }
 }


### PR DESCRIPTION
1. `PgTableAnalyzer.BuildTableFunctionStructure()` 에서 동일한 identifier를 갖는 테이블 함수 목록 중 필요한 처리를 수행해야 하는 테이블 함수를 찾을 때, 필터링 조건으로 기존 코드는 '인자 개수가 일치하지 않는 경우'를 필터링 하도록 했습니다. 

2. 예를 들어 `aws_lambda.invoke()` 함수의 경우 인자 개수가 6-7 개 가량 되는 경우가 있는데, 이 중 required는 2개고 나머지는 default가 있어 실제로 쿼리를 호출할 때는 인자 2개만 전달하는 경우가 있습니다. 그런데 기존 코드는 단순히 '6개와 2개는 다르므로 필터링 대상'으로 보는 경우가 있었습니다.

3. 이 PR은 `QsiFunctionObject`에 `DefaultArgumentsCount` 프로퍼티를 추가하여, 테이블 함수 목록을 가져올 때 해당 함수가 갖는 인자의 default 값 또한 가져왔을 때, 이를 통해 위와 같은 필터링 상황에서 보다 정확히 필터링 할 수 있게 합니다.

4. 더불어, 테이블 함수 목록 가져올 때 해당 함수가 갖는 인자의 default 값을 함께 적절히 가져오는 예시 테스트 코드를 추가합니다.