### PR TITLE
[QP-8003] PgActionAnalyzer에서 Insert Action 시 명시적 컬럼 지정이 있는 경우에는 base 메소드 호출

### DIFF
--- a/Qsi.PostgreSql/Analyzers/PgActionAnalyzer.cs
+++ b/Qsi.PostgreSql/Analyzers/PgActionAnalyzer.cs
@@ -9,6 +9,7 @@ using Qsi.Data;
 using Qsi.Engines;
 using Qsi.PostgreSql.Tree.Nodes;
 using Qsi.Tree;
+using Qsi.Utilities;
 
 namespace Qsi.PostgreSql.Analyzers;
 
@@ -20,7 +21,7 @@ public class PgActionAnalyzer : QsiActionAnalyzer
 
     protected override async ValueTask<ColumnTarget[]> ResolveColumnTargetsFromDataInsertActionAsync(IAnalyzerContext context, QsiTableStructure table, IQsiDataInsertActionNode action)
     {
-        if (action.Columns.Length == 0 && action.ValueTable is PgDerivedTableNode pgDerivedTableNode)
+        if (ListUtility.IsNullOrEmpty(action.Columns) && action.ValueTable is PgDerivedTableNode pgDerivedTableNode)
         {
             var tableAnalyzer = context.Engine.GetAnalyzer<QsiTableAnalyzer>();
             using var tableContext = new TableCompileContext(context);

--- a/Qsi.PostgreSql/Analyzers/PgActionAnalyzer.cs
+++ b/Qsi.PostgreSql/Analyzers/PgActionAnalyzer.cs
@@ -1,8 +1,6 @@
-using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using Qsi.Analyzers.Action;
-using Qsi.Analyzers.Action.Context;
 using Qsi.Analyzers.Action.Models;
 using Qsi.Analyzers.Context;
 using Qsi.Analyzers.Table;
@@ -11,7 +9,6 @@ using Qsi.Data;
 using Qsi.Engines;
 using Qsi.PostgreSql.Tree.Nodes;
 using Qsi.Tree;
-using Qsi.Utilities;
 
 namespace Qsi.PostgreSql.Analyzers;
 
@@ -23,7 +20,7 @@ public class PgActionAnalyzer : QsiActionAnalyzer
 
     protected override async ValueTask<ColumnTarget[]> ResolveColumnTargetsFromDataInsertActionAsync(IAnalyzerContext context, QsiTableStructure table, IQsiDataInsertActionNode action)
     {
-        if (action.ValueTable is PgDerivedTableNode pgDerivedTableNode)
+        if (action.Columns.Length == 0 && action.ValueTable is PgDerivedTableNode pgDerivedTableNode)
         {
             var tableAnalyzer = context.Engine.GetAnalyzer<QsiTableAnalyzer>();
             using var tableContext = new TableCompileContext(context);

--- a/Qsi.Tests/Vendor/MySql/Driver/MySqlRepositoryProvider.cs
+++ b/Qsi.Tests/Vendor/MySql/Driver/MySqlRepositoryProvider.cs
@@ -59,7 +59,7 @@ limit 1";
         }
 
         sql = @$"
-select COLUMN_NAME 
+select COLUMN_NAME, IS_NULLABLE, COLUMN_DEFAULT
 from information_schema.COLUMNS
 where TABLE_SCHEMA = '{names[0]}' and TABLE_NAME = '{names[1]}'
 order by ORDINAL_POSITION";
@@ -70,6 +70,8 @@ order by ORDINAL_POSITION";
             {
                 var column = table.NewColumn();
                 column.Name = new QsiIdentifier(reader.GetString(0), false);
+                column.IsNullable = reader.GetString(1) == "YES";
+                column.Default = reader.IsDBNull(2) ? null : reader.GetString(2);
             }
         }
 

--- a/Qsi.Tests/Vendor/PostgreSql/PostgreSqlTest.cs
+++ b/Qsi.Tests/Vendor/PostgreSql/PostgreSqlTest.cs
@@ -292,7 +292,9 @@ col2 VARCHAR
         string[] queries =
         {
             "INSERT INTO test_not_null VALUES (null, 'test')",
-            "INSERT INTO test_not_null (col2) VALUES ('test')"
+            "INSERT INTO test_not_null (col2) VALUES ('test')",
+            "INSERT INTO test_not_null SELECT null, 'test'",
+            "INSERT INTO test_not_null (col2) SELECT 'test'"
         };
 
         const string errorMessage = "QSI-0021: The column 'col1' has a Not Null constraint.";


### PR DESCRIPTION
1. `INSERT INTO [테이블명] [SELECT 쿼리]` 의 경우 PostgreSQL는 대상 컬럼이 암시적(implicit)으로 지정됐다고 보고 SELECT 쿼리에서 확인되는 컬럼의 개수만큼 기존 테이블의 가장 왼쪽 컬럼에서부터 차례대로 컬럼을 추출해 Insert Action을 수행합니다. (문서 참조: https://www.postgresql.org/docs/current/sql-insert.html )

2. `INSERT INTO [테이블명] (컬럼1, 컬럼2, ...) [SELECT 쿼리]` 의 경우 대부분 RDBMS는 Insert Action의 대상 컬럼이 명시적으로 지정되었다고 보고 지정된 각 컬럼에 SELECT 쿼리에서 얻은 결과를 테이블에 삽입하나, 기존 QSI 코드의 PgActionAnalyzer의 경우 Insert Action 쿼리에 `[SELECT 쿼리]` 가 포함되면 일괄적으로 암시적 컬럼 지정으로 보고 처리합니다. 이렇게 되면, 잘못된 컬럼을 지정해 null 대입을 시도하는 등의 문제가 발생합니다. 이 PR은 명시적 컬럼 지정이 있는 경우를 세분화, 적절히 처리합니다. 또한, 이를 확인할 수 있는 테스트 데이터를 추가합니다.

3. 추가로, base 메소드의 정상 작동을 확인하기 위해 (이를 override 하지 않는) MySQL 관련 테스트 코드를 추가합니다.