### PR TITLE
[QP-8036] PgTableAnalyzer.BuildTableFunctionStructure에서, 리턴 테이블에 컬럼 이름 있는 경우 그 이름 가져오기

### DIFF
--- a/Qsi.PostgreSql/Analyzers/PgTableAnalyzer.cs
+++ b/Qsi.PostgreSql/Analyzers/PgTableAnalyzer.cs
@@ -137,6 +137,16 @@ public class PgTableAnalyzer : QsiTableAnalyzer
                         column.Name = outParam.Name;
                     }
 
+                    var tableParams = funcDef.Parameters.WhereNotNull().Where(p => p.Mode is FunctionParameterMode.FuncParamTable);
+
+                    foreach (var tableParam in tableParams)
+                    {
+                        count++;
+
+                        var column = structure.NewColumn();
+                        column.Name = tableParam.Name;
+                    }
+
                     if (count == 0)
                     {
                         var returnType = funcDef.ReturnType.Value;

--- a/Qsi.Tests/Vendor/PostgreSql/PostgreSqlTest.cs
+++ b/Qsi.Tests/Vendor/PostgreSql/PostgreSqlTest.cs
@@ -435,4 +435,30 @@ $$ LANGUAGE plpgsql;
             });
         }
     }
+
+    /// <summary>
+    /// 테이블 함수가 리턴하는 테이블의 컬럼 이름을 사용하는 경우에 대해 테스트를 수행합니다.
+    /// </summary>
+    [Test]
+    public async Task Test_TableFunctionWithColumnNameInReturnedTable()
+    {
+        const string CreateTableFunctionQuery = @"
+CREATE OR REPLACE FUNCTION table_function_with_column_name_in_returned_table()
+RETURNS TABLE(column1 text) AS $$
+BEGIN
+    RETURN QUERY SELECT '1' AS column1;
+END;
+$$ LANGUAGE plpgsql;
+";
+
+        var command = Connection.CreateCommand();
+        command.CommandText = CreateTableFunctionQuery;
+        await command.ExecuteNonQueryAsync();
+        const string Query = "select column1 from table_function_with_column_name_in_returned_table();";
+
+        Assert.DoesNotThrowAsync(async () =>
+        {
+            await Engine.Execute(new QsiScript(Query, QsiScriptType.Select), null);
+        });
+    }
 }


### PR DESCRIPTION
1. 현재 Qsi.PostgreSql는 nuget의 PgQuery을 사용하는데, PgQuery는 테이블 함수를 포함하는 쿼리를 파싱하도록 하면, 만약 해당 테이블 함수가 리턴값으로 컬럼을 갖는 테이블을 리턴하면, 그 함수에 해당하는 노드가 갖는 `Parameter` 목록에 그 함수의 매개변수와 그 함수가 리턴하는 테이블의 컬럼들을 모두 포함해서 리턴합니다. (테이블 함수가 리턴값으로 컬럼을 갖는 테이블을 리턴하지 않는다면  `Parameter` 목록에 리턴값에 관한 정보가 포함되지는 않습니다.)

2. 기존 Qsi.PostgreSql 은 이처럼 테이블 함수의 리턴값이 컬럼을 갖는 테이블인 경우에 관한 처리가 없어, 테이블 함수의 리턴 테이블에서 컬럼이름으로 값을 가져오려 할 경우 '그러한 컬럼이 없다'는 에러가 발생합니다. 이 PR은 그에 관한 구현을 추가하여 이 에러를 해결합니다.