### PR TITLE
[QP-6630] WHERE 조건문 내에서 사용한 column에 대한 순회 구현

### DIFF
--- a/Qsi.Debugger/MainWindow.axaml
+++ b/Qsi.Debugger/MainWindow.axaml
@@ -147,6 +147,10 @@
                         <Rectangle Margin="0,6" Fill="{DynamicResource ThemeBackgroundBrush}" Height="2" />
                     </TreeDataTemplate>
 
+                    <TreeDataTemplate DataType="md:QsiLabelTreeItem">
+                        <TextBlock Foreground="LightGray" Text="{Binding Label}"></TextBlock>
+                    </TreeDataTemplate>
+
                     <TreeDataTemplate DataType="md:QsiColumnTreeItem" ItemsSource="{Binding Items}">
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Foreground="{Binding Converter={cvt:ColumnBrushConverter}}"

--- a/Qsi.Debugger/MainWindow.axaml.cs
+++ b/Qsi.Debugger/MainWindow.axaml.cs
@@ -457,6 +457,13 @@ public class MainWindow : Window
                 items.Add(new QsiSplitTreeItem());
 
             items.AddRange(tables[i].Columns.Select(c => new QsiColumnTreeItem(c)));
+
+            // Indirect columns
+            if (tables[i].IndirectColumns is not { } indirectColumns)
+                continue;
+
+            items.Add(new QsiLabelTreeItem("Indirect Columns"));
+            items.AddRange(indirectColumns.Select(c => new QsiColumnTreeItem(c)));
         }
 
         _tvResult.Items = items;

--- a/Qsi.Debugger/Models/QsiLabelTreeItem.cs
+++ b/Qsi.Debugger/Models/QsiLabelTreeItem.cs
@@ -1,0 +1,11 @@
+namespace Qsi.Debugger.Models;
+
+public class QsiLabelTreeItem
+{
+    public string Label { get; }
+
+    public QsiLabelTreeItem(string label)
+    {
+        Label = label;
+    }
+}

--- a/Qsi/Analyzers/Expression/ColumnResolver.cs
+++ b/Qsi/Analyzers/Expression/ColumnResolver.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Qsi.Analyzers.Extensions;
+using Qsi.Analyzers.Table.Context;
+using Qsi.Data;
+using Qsi.Extensions;
+using Qsi.Services;
+using Qsi.Shared.Extensions;
+using Qsi.Tree;
+
+namespace Qsi.Analyzers.Expression;
+
+public class ColumnResolver : ExpressionResolver<QsiTableColumn>
+{
+    public delegate ValueTask<QsiTableStructure> BuildTableStructureDelegate(TableCompileContext context, IQsiTableNode table);
+
+    private const string scopeFieldList = "field list";
+
+    protected readonly IQsiLanguageService _languageService;
+    protected readonly BuildTableStructureDelegate _buildTableStructureDelegate;
+
+    public ColumnResolver(IQsiLanguageService languageService, BuildTableStructureDelegate buildTableStructureDelegate)
+    {
+        _languageService = languageService;
+        _buildTableStructureDelegate = buildTableStructureDelegate;
+    }
+
+    protected override IEnumerable<QsiTableColumn> ResolveTableExpression(TableCompileContext context, IQsiTableExpressionNode expression)
+    {
+        using var scopedContext = new TableCompileContext(context);
+        var structure = _buildTableStructureDelegate(scopedContext, expression.Table).Result;
+
+        foreach (var c in structure.Columns)
+            yield return c;
+    }
+
+    protected override IEnumerable<QsiTableColumn> ResolveColumnExpression(TableCompileContext context, IQsiColumnExpressionNode expression)
+    {
+        switch (expression.Column)
+        {
+            case IQsiAllColumnNode _ when
+                expression.FindDescendant<IQsiParametersExpressionNode, IQsiInvokeExpressionNode>(out _, out var i) &&
+                i.Member != null &&
+                i.Member.Identifier.Level == 1 &&
+                i.Member.Identifier[0].Value.EqualsIgnoreCase("COUNT"):
+                yield break;
+
+            case IQsiAllColumnNode allColumnNode:
+            {
+                foreach (var column in ResolveAllColumns(context, allColumnNode, true))
+                    yield return column;
+
+                break;
+            }
+
+            case IQsiColumnReferenceNode columnReferenceNode:
+                foreach (var column in ResolveColumnReference(context, columnReferenceNode, out _))
+                    yield return column;
+
+                break;
+
+            default:
+                throw new InvalidOperationException();
+        }
+    }
+
+    private IEnumerable<QsiTableColumn> ResolveAllColumns(TableCompileContext context, IQsiAllColumnNode column, bool includeInvisible)
+    {
+        context.ThrowIfCancellationRequested();
+
+        includeInvisible |= column.IncludeInvisibleColumns;
+
+        // *
+        if (column.Path == null)
+        {
+            if (context.SourceTable == null)
+                throw new QsiException(QsiError.NoTablesUsed);
+
+            return includeInvisible ?
+                context.SourceTable.Columns :
+                context.SourceTable.VisibleColumns;
+        }
+
+        // path.or.alias.*
+
+        IEnumerable<QsiTableStructure> tables = LookupDataTableStructuresInExpression(context, column.Path);
+
+        if (!tables.Any())
+            throw new QsiException(QsiError.UnknownTable, column.Path);
+
+        return tables.SelectMany(t => includeInvisible ? t.Columns : t.VisibleColumns);
+    }
+
+    private IEnumerable<QsiTableColumn> ResolveColumnReference(TableCompileContext context, IQsiColumnReferenceNode column, out QsiQualifiedIdentifier implicitTableWildcardTarget)
+    {
+        context.ThrowIfCancellationRequested();
+
+        if (column.Name.Level == 0)
+            throw new QsiException(QsiError.UnknownColumnIn, "null", scopeFieldList);
+
+        IEnumerable<TableCompileContext> candidateContexts =
+            context.AnalyzerOptions.UseOuterQueryColumn ? context.AncestorsAndSelf() : new[] { context };
+
+        var lastName = column.Name[^1];
+
+        foreach (var candidateContext in candidateContexts)
+        {
+            if (candidateContext.SourceTable == null)
+                continue;
+
+            IEnumerable<QsiTableStructure> candidateSourceTables;
+
+            if (column.Name.Level > 1)
+            {
+                var identifier = new QsiQualifiedIdentifier(column.Name[..^1]);
+
+                candidateSourceTables = LookupDataTableStructuresInExpression(candidateContext, identifier);
+
+                if (!candidateSourceTables.Any())
+                    continue;
+            }
+            else
+            {
+                candidateSourceTables = new[] { candidateContext.SourceTable };
+            }
+
+            QsiTableColumn[] columns = candidateSourceTables
+                .SelectMany(s => s.Columns.Where(c => _languageService.MatchIdentifier(c.Name, lastName) && c.IsVisible))
+                .Take(2)
+                .ToArray();
+
+            // If visible column is not exists, get invisible columns
+            if (columns.Length is 0)
+            {
+                columns = candidateSourceTables
+                    .SelectMany(s => s.Columns.Where(c => _languageService.MatchIdentifier(c.Name, lastName) && !c.IsVisible))
+                    .Take(2)
+                    .ToArray();
+            }
+
+            switch (columns.Length)
+            {
+                case 0:
+                    break;
+
+                case > 1:
+                    throw new QsiException(QsiError.AmbiguousColumnIn, column.Name, scopeFieldList);
+
+                default:
+                    implicitTableWildcardTarget = default;
+                    return new[] { columns[0] };
+            }
+        }
+
+        // NOTE: 'SELECT actor FROM actor' same as
+        //       'SELECT actor.* FROM actor'
+        if (context.AnalyzerOptions.UseImplicitTableWildcardInSelect)
+            return ImplicitlyResolveColumnReference(context, column, out implicitTableWildcardTarget);
+
+        throw new QsiException(QsiError.UnknownColumnIn, lastName.Value, scopeFieldList);
+    }
+
+    private IEnumerable<QsiTableStructure> LookupDataTableStructuresInExpression(TableCompileContext context, QsiQualifiedIdentifier identifier)
+    {
+        context.ThrowIfCancellationRequested();
+        return context.GetAllSourceTables().Where(x => _languageService.MatchIdentifier(context, x, identifier));
+    }
+
+    private QsiTableColumn[] ImplicitlyResolveColumnReference(TableCompileContext context, IQsiColumnReferenceNode column, out QsiQualifiedIdentifier implicitTableWildcardTarget)
+    {
+        QsiTableStructure[] implicitSources = LookupDataTableStructuresInExpression(context, column.Name).ToArray();
+
+        if (implicitSources.Length != 1)
+            throw new QsiException(QsiError.UnknownColumnIn, column.Name[^1], scopeFieldList);
+
+        implicitTableWildcardTarget = column.Name;
+        return implicitSources[0].Columns.ToArray();
+    }
+}

--- a/Qsi/Analyzers/Expression/ExpressionResolver.cs
+++ b/Qsi/Analyzers/Expression/ExpressionResolver.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Qsi.Analyzers.Table.Context;
+using Qsi.Tree;
+
+namespace Qsi.Analyzers.Expression;
+
+public abstract class ExpressionResolver<T>
+{
+    public IEnumerable<T> GetValues(TableCompileContext context, IQsiExpressionNode expression)
+    {
+        context.ThrowIfCancellationRequested();
+
+        if (expression is null)
+            yield break;
+
+        switch (expression)
+        {
+            case IQsiTableExpressionNode table:
+                foreach (var value in ResolveTableExpression(context, table))
+                    yield return value;
+
+                break;
+
+            case IQsiColumnExpressionNode column:
+                foreach (var value in ResolveColumnExpression(context, column))
+                    yield return value;
+
+                break;
+
+            default:
+                foreach (var value in ResolveCommonExpression(context, expression))
+                    yield return value;
+
+                break;
+        }
+    }
+
+    protected abstract IEnumerable<T> ResolveTableExpression(TableCompileContext context, IQsiTableExpressionNode expression);
+
+    protected abstract IEnumerable<T> ResolveColumnExpression(TableCompileContext context, IQsiColumnExpressionNode expression);
+
+    private IEnumerable<T> ResolveCommonExpression(TableCompileContext context, IQsiExpressionNode expression)
+    {
+        switch (expression)
+        {
+            case QsiExpressionFragmentNode:
+                break;
+
+            case IQsiSetColumnExpressionNode e:
+            {
+                foreach (var c in GetValues(context, e.Value))
+                    yield return c;
+
+                break;
+            }
+
+            case IQsiSetVariableExpressionNode e:
+            {
+                foreach (var c in GetValues(context, e.Value))
+                    yield return c;
+
+                break;
+            }
+
+            case IQsiInvokeExpressionNode e:
+            {
+                foreach (var c in GetValues(context, e.Member))
+                    yield return c;
+
+                foreach (var c in GetValues(context, e.Parameters))
+                    yield return c;
+
+                break;
+            }
+
+            case IQsiLiteralExpressionNode e:
+            {
+                break;
+            }
+
+            case IQsiBinaryExpressionNode e:
+            {
+                foreach (var c in GetValues(context, e.Left))
+                    yield return c;
+
+                foreach (var c in GetValues(context, e.Right))
+                    yield return c;
+
+                break;
+            }
+
+            case IQsiParametersExpressionNode e:
+            {
+                foreach (var c in e.Expressions.SelectMany(x => GetValues(context, x)))
+                    yield return c;
+
+                break;
+            }
+
+            case IQsiMultipleExpressionNode e:
+            {
+                foreach (var c in e.Elements.SelectMany(x => GetValues(context, x)))
+                    yield return c;
+
+                break;
+            }
+
+            case IQsiSwitchExpressionNode e:
+            {
+                foreach (var c in GetValues(context, e.Value))
+                    yield return c;
+
+                foreach (var c in e.Cases.SelectMany(c => GetValues(context, c)))
+                    yield return c;
+
+                break;
+            }
+
+            case IQsiSwitchCaseExpressionNode e:
+            {
+                foreach (var c in GetValues(context, e.Condition))
+                    yield return c;
+
+                foreach (var c in GetValues(context, e.Consequent))
+                    yield return c;
+
+                break;
+            }
+
+            case IQsiUnaryExpressionNode e:
+            {
+                foreach (var c in GetValues(context, e.Expression))
+                    yield return c;
+
+                break;
+            }
+
+            case IQsiMemberAccessExpressionNode e:
+            {
+                foreach (var c in GetValues(context, e.Target))
+                    yield return c;
+
+                foreach (var c in GetValues(context, e.Member))
+                    yield return c;
+
+                break;
+            }
+
+            case IQsiOrderExpressionNode e:
+            {
+                foreach (var c in GetValues(context, e.Expression))
+                    yield return c;
+
+                break;
+            }
+
+            case IQsiVariableExpressionNode e:
+            {
+                // TODO: Analyze variable
+                break;
+            }
+
+            case IQsiFunctionExpressionNode e:
+            {
+                // TODO: Analyze function
+                break;
+            }
+
+            case IQsiMemberExpressionNode _:
+            {
+                // Skip unknown member access
+                break;
+            }
+
+            case IQsiBindParameterExpressionNode:
+                break;
+
+            default:
+                throw new InvalidOperationException();
+        }
+    }
+}

--- a/Qsi/Analyzers/Expression/IndirectColumnResolver.cs
+++ b/Qsi/Analyzers/Expression/IndirectColumnResolver.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using Qsi.Analyzers.Table.Context;
+using Qsi.Data;
+using Qsi.Services;
+using Qsi.Tree;
+
+namespace Qsi.Analyzers.Expression;
+
+public sealed class IndirectColumnResolver : ColumnResolver
+{
+    public IndirectColumnResolver(IQsiLanguageService languageService, BuildTableStructureDelegate buildTableStructureDelegate)
+        : base(languageService, buildTableStructureDelegate)
+    {
+    }
+
+    protected override IEnumerable<QsiTableColumn> ResolveTableExpression(TableCompileContext context, IQsiTableExpressionNode expression)
+    {
+        using var scopedContext = new TableCompileContext(context);
+        var structure = _buildTableStructureDelegate(scopedContext, expression.Table).Result;
+
+        foreach (var c in structure.Columns)
+            yield return c;
+
+        if (structure.IndirectColumns is null)
+            yield break;
+
+        foreach (var c in structure.IndirectColumns)
+            yield return c;
+    }
+}

--- a/Qsi/Analyzers/Extensions/QsiLanguageServiceExtension.cs
+++ b/Qsi/Analyzers/Extensions/QsiLanguageServiceExtension.cs
@@ -1,0 +1,74 @@
+using Qsi.Analyzers.Context;
+using Qsi.Data;
+using Qsi.Services;
+using Qsi.Utilities;
+
+namespace Qsi.Analyzers.Extensions;
+
+public static class QsiLanguageServiceExtension
+{
+    public static bool MatchIdentifier(
+        this IQsiLanguageService languageService,
+        QsiQualifiedIdentifier a,
+        QsiQualifiedIdentifier b)
+    {
+        if (a.Level != b.Level)
+            return false;
+
+        for (int i = 0; i < a.Level; i++)
+        {
+            if (!languageService.MatchIdentifier(a[i], b[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    public static bool MatchIdentifier(
+        this IQsiLanguageService languageService,
+        IAnalyzerContext context,
+        QsiTableStructure table,
+        QsiQualifiedIdentifier identifier)
+    {
+        if (!table.HasIdentifier)
+            return false;
+
+        // * case - Explicit access
+        // ┌──────────────────────────────────────────────────────────┐
+        // │ SELECT sakila.actor.column FROM sakila.actor             │
+        // │        ▔▔▔▔▔▔^▔▔▔▔▔      ==     ▔▔▔▔▔▔^▔▔▔▔▔             │
+        // │         └-> identifier(2)        └-> table.Identifier(2) │
+        // └──────────────────────────────────────────────────────────┘ 
+
+        if (MatchIdentifier(languageService, table.Identifier, identifier))
+            return true;
+
+        // * case - 2 Level implicit access
+        // ┌──────────────────────────────────────────────────────────┐
+        // │ SELECT actor.column FROM sakila.actor                    │
+        // │        ▔▔▔▔▔      <       ▔▔▔▔▔^▔▔▔▔▔                    │
+        // │         └-> identifier(1)  └-> table.Identifier(2)       │
+        // └──────────────────────────────────────────────────────────┘ 
+
+        // * case - 3 Level implicit access
+        // ┌──────────────────────────────────────────────────────────┐
+        // │ SELECT sakila.actor.column FROM db.sakila.actor          │
+        // │        ▔▔▔▔▔▔^▔▔▔▔▔       <     ▔▔^▔▔▔▔▔▔^▔▔▔▔▔          │
+        // │         └-> identifier(2)        └-> table.Identifier(3) │
+        // └──────────────────────────────────────────────────────────┘ 
+
+        if (context.AnalyzerOptions.UseExplicitRelationAccess)
+            return false;
+
+        if (!QsiUtility.IsReferenceType(table.Type))
+            return false;
+
+        if (table.Identifier.Level <= identifier.Level)
+            return false;
+
+        QsiIdentifier[] partialIdentifiers = table.Identifier[^identifier.Level..];
+        var partialIdentifier = new QsiQualifiedIdentifier(partialIdentifiers);
+
+        return MatchIdentifier(languageService, partialIdentifier, identifier);
+    }
+}

--- a/Qsi/Data/Table/QsiTableStructure.cs
+++ b/Qsi/Data/Table/QsiTableStructure.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Qsi.Shared.Extensions;
 
@@ -17,6 +18,12 @@ public sealed class QsiTableStructure
     public IList<QsiTableStructure> References { get; } = new List<QsiTableStructure>();
 
     public IList<QsiTableColumn> Columns => _columns;
+
+    /// <summary>
+    /// 테이블을 직접적으로 구성하는 컬럼이 아닌, Where문 등을 통해 간접적으로 참조하는 컬럼을 의미합니다.
+    /// 마지막 수정인 9.19.0 기준 where expression 내부의 모든 컬럼을 조사합니다.
+    /// </summary>
+    public QsiTableColumn[] IndirectColumns = Array.Empty<QsiTableColumn>();
 
     internal IEnumerable<QsiTableColumn> VisibleColumns => _columns.Where(c => c.IsVisible);
 
@@ -46,6 +53,7 @@ public sealed class QsiTableStructure
 
         table.References.AddRange(References);
         table._columns.AddRange(_columns.Select(c => c.CloneInternal()));
+        table.IndirectColumns = (QsiTableColumn[])IndirectColumns.Clone();
 
         return table;
     }
@@ -62,6 +70,7 @@ public sealed class QsiTableStructure
 
         table.References.AddRange(References);
         table._columns.AddRange(VisibleColumns.Select(c => c.CloneInternal()));
+        table.IndirectColumns = (QsiTableColumn[])IndirectColumns.Clone();
 
         return table;
     }


### PR DESCRIPTION
# 개요
WHERE 절 내에서 사용한 column에 대한 접근 제한을 구현하기 위해, 사용한 column에 대한 순회를 구현합니다.

## 예시

### 상황
- `actor` 테이블의 `first_name`에 대해 마스킹 정책을 걸었습니다.
-  다음 쿼리를 수행합니다.

```
SELECT * FROM actor where last_name = "GUINESS" && first_name = ‘Mason’
```

### AS-IS

- WHERE 절의 조건을 만족하는 row들의 결과가 내려옵니다.
- 즉, 사용자는 row 결과가 마스킹되어 있더라도 해당 row들의 `first_name`이 `'Mason'`임을 알 수 있습니다.

### TO-BE

- WHERE 절 내에 Data Access 또는 Data Masking이 걸려 있을 경우, 접근 정책 위반 예외를 내립니다.

# 상세

- Where 절 내에서 사용하는 column은 실제 조회하는 테이블을 구성하지 않을 수도 있기 때문에, `IndirectColumn`으로 명명했습니다.
- Where 절 노드 내에서 column을 추출하는 `IndirectColumnResolver`를 추가했습니다.
  - 참고로 `ColumnResolver`는 기존 로직과 동일합니다.
- `IndirectColumn`을 디버거에서 볼 수 있는 기능을 추가했습니다.

# 한계

- 현재 조사하는 내용은 where 절 내의 column에 국한되어 있습니다.
  - 즉, table 단위로 정책을 적용할 경우 접근 제한이 동작하지 않습니다.
- 이후 table 정보와 column 정보 모두 내려주는 방법으로 구현할 예정입니다.