### PR TITLE
[QP-6630] Where절에서 사용한 컬럼에 대한 정보를 제공합니다.

### DIFF
--- a/Qsi.Debugger/MainWindow.axaml
+++ b/Qsi.Debugger/MainWindow.axaml
@@ -147,6 +147,10 @@
                         <Rectangle Margin="0,6" Fill="{DynamicResource ThemeBackgroundBrush}" Height="2" />
                     </TreeDataTemplate>
 
+                    <TreeDataTemplate DataType="md:QsiLabelTreeItem">
+                        <TextBlock Foreground="LightGray" Text="{Binding Label}"></TextBlock>
+                    </TreeDataTemplate>
+
                     <TreeDataTemplate DataType="md:QsiColumnTreeItem" ItemsSource="{Binding Items}">
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Foreground="{Binding Converter={cvt:ColumnBrushConverter}}"

--- a/Qsi.Debugger/MainWindow.axaml.cs
+++ b/Qsi.Debugger/MainWindow.axaml.cs
@@ -457,6 +457,13 @@ public class MainWindow : Window
                 items.Add(new QsiSplitTreeItem());
 
             items.AddRange(tables[i].Columns.Select(c => new QsiColumnTreeItem(c)));
+
+            // Indirect columns
+            if (tables[i].IndirectColumns is not { } indirectColumns)
+                continue;
+
+            items.Add(new QsiLabelTreeItem("Indirect Columns"));
+            items.AddRange(indirectColumns.Select(c => new QsiColumnTreeItem(c)));
         }
 
         _tvResult.Items = items;

--- a/Qsi.Debugger/Models/QsiLabelTreeItem.cs
+++ b/Qsi.Debugger/Models/QsiLabelTreeItem.cs
@@ -1,0 +1,11 @@
+namespace Qsi.Debugger.Models;
+
+public class QsiLabelTreeItem
+{
+    public string Label { get; }
+
+    public QsiLabelTreeItem(string label)
+    {
+        Label = label;
+    }
+}

--- a/Qsi/Analyzers/Table/Context/TableCompileContext.cs
+++ b/Qsi/Analyzers/Table/Context/TableCompileContext.cs
@@ -18,6 +18,8 @@ public sealed class TableCompileContext : AnalyzerContextWrapper, IDisposable
 
     public List<QsiTableStructure> JoinedSouceTables { get; }
 
+    public bool IsIndirectSource { get; set; }
+
     private readonly List<QsiTableStructure> _directives;
     private Stack<QsiQualifiedIdentifier> _identifierScope;
 

--- a/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
+++ b/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
@@ -285,6 +285,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
             }
         }
 
+        scopedContext.IsIndirectSource = true;
         declaredTable.IndirectColumns = GetIndirectColumns(scopedContext, table).ToArray() ?? Array.Empty<QsiTableColumn>();
 
         return declaredTable;
@@ -305,9 +306,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
         if (table.Where is not { } where)
             yield break;
 
-        context.IsIndirectSource = true;
         IEnumerable<QsiTableColumn> columns = ResolveColumnsInExpression(context, where.Expression);
-        context.IsIndirectSource = false;
 
         foreach (var c in columns)
             yield return c;

--- a/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
+++ b/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
@@ -287,6 +287,7 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
 
         scopedContext.IsIndirectSource = true;
         declaredTable.IndirectColumns = GetIndirectColumns(scopedContext, table).ToArray() ?? Array.Empty<QsiTableColumn>();
+        scopedContext.IsIndirectSource = false;
 
         return declaredTable;
     }

--- a/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
+++ b/Qsi/Analyzers/Table/QsiTableAnalyzer.cs
@@ -285,7 +285,32 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
             }
         }
 
+        declaredTable.IndirectColumns = GetIndirectColumns(scopedContext, table).ToArray() ?? Array.Empty<QsiTableColumn>();
+
         return declaredTable;
+    }
+
+    private IEnumerable<QsiTableColumn> GetIndirectColumns(TableCompileContext context, IQsiDerivedTableNode table)
+    {
+        // Indirect columns from sources
+        foreach (var t in context.GetAllSourceTables())
+        {
+            if (t.IndirectColumns is not { } indirectColumns)
+                continue;
+
+            foreach (var c in indirectColumns)
+                yield return c;
+        }
+
+        if (table.Where is not { } where)
+            yield break;
+
+        context.IsIndirectSource = true;
+        IEnumerable<QsiTableColumn> columns = ResolveColumnsInExpression(context, where.Expression);
+        context.IsIndirectSource = false;
+
+        foreach (var c in columns)
+            yield return c;
     }
 
     protected virtual QsiIdentifier ResolveCompoundColumnName(TableCompileContext context, IQsiDerivedTableNode table, IQsiColumnNode column, QsiTableColumn refColumn)
@@ -951,10 +976,18 @@ public class QsiTableAnalyzer : QsiAnalyzerBase
 
             case IQsiTableExpressionNode e:
             {
+                var isIndirectSource = context.IsIndirectSource;
+
                 using var scopedContext = new TableCompileContext(context);
                 var structure = BuildTableStructure(scopedContext, e.Table).Result;
 
                 foreach (var c in structure.Columns)
+                    yield return c;
+
+                if (!isIndirectSource)
+                    break;
+
+                foreach (var c in structure.IndirectColumns)
                     yield return c;
 
                 break;

--- a/Qsi/Data/Table/QsiTableStructure.cs
+++ b/Qsi/Data/Table/QsiTableStructure.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Qsi.Shared.Extensions;
 
@@ -17,6 +18,17 @@ public sealed class QsiTableStructure
     public IList<QsiTableStructure> References { get; } = new List<QsiTableStructure>();
 
     public IList<QsiTableColumn> Columns => _columns;
+
+    /// <summary>
+    /// 테이블을 직접적으로 구성하는 컬럼이 아닌 간접적으로 참조하는 컬럼을 의미합니다.
+    /// </summary>
+    /// <remarks>
+    /// <ul>
+    /// <li>WHERE문이나 HAVING문의 조건에서 사용하는 컬럼이나, 서브쿼리 내에 들어 있는 컬럼 등을 포함합니다.</li>
+    /// <li>주석 작성일 기준으로 해당 필드의 값은 WHERE절 내부에서 사용하는 컬럼들만 포함하고 있습니다.</li>
+    /// </ul>
+    /// </remarks>
+    public QsiTableColumn[] IndirectColumns = Array.Empty<QsiTableColumn>();
 
     internal IEnumerable<QsiTableColumn> VisibleColumns => _columns.Where(c => c.IsVisible);
 
@@ -46,6 +58,7 @@ public sealed class QsiTableStructure
 
         table.References.AddRange(References);
         table._columns.AddRange(_columns.Select(c => c.CloneInternal()));
+        table.IndirectColumns = (QsiTableColumn[])IndirectColumns.Clone();
 
         return table;
     }
@@ -62,6 +75,7 @@ public sealed class QsiTableStructure
 
         table.References.AddRange(References);
         table._columns.AddRange(VisibleColumns.Select(c => c.CloneInternal()));
+        table.IndirectColumns = (QsiTableColumn[])IndirectColumns.Clone();
 
         return table;
     }


### PR DESCRIPTION
# 개요
- Where 절에서 사용한 컬럼에 대한 정보를 얻을 수 있도록 추가합니다.
- 실제 조회 시 사용하는 테이블에 포함되지 않는 컬럼이므로, 이름을 `IndirectColumn`으로 정했습니다.

> 현재 구현은 변경을 최소화하는 것을 최우선으로 하였습니다.
>
> 향후 QSI의 Analysis쪽 구현을 변경하여, 레이어를 하나 더 추가하여 관심사를 더욱 분리하고자 합니다.
> 자세한 구현 내용은 추후 컨플루언스 작성 후 해당 PR에 댓글로 달아놓도록 하겠습니다.

# 변경점
## 주요 사항
- `QsiTableStructure`에 `IndirectColumn`을 추가합니다.
- `QsiTableAnalyzer`에서 `IndirectColumn`을 조회합니다.
  - `BuildDerivedTableStructure` 메서드에서, where 절에서 사용하는 컬럼들을 `IndirectColumns`에 저장합니다.
  - `TableCompileContext`에 `IsIndirectSource`라는 플래그를 하나 추가합니다.
  - 해당 플래그가 참일 경우,
    - `ResolveColumnsInExpression` 메서드에서 `TableExpression`을 대상으로 컬럼을 가져올 때,
    - 추가적으로 해당 테이블의 `IndirectColumn`들까지 가져오도록 합니다.

## 기타
- Debugger에서 `IndirectColumn`를 볼 수 있도록 합니다.

# 이슈
QP-6630