### PR TITLE
QD-0 Remove CodeQL workflow trigger on push and pr

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,11 +12,6 @@
 name: 🔍 CodeQL
 
 on:
-  push:
-    branches: ["main"]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ["main"]
   schedule:
     - cron: "0 20 * * 0"
   workflow_dispatch:


### PR DESCRIPTION
CodeQL이 Self-hosted 러너를 과도하게 사용합니다.
Push 및 PR에 의해 동작하지 않도록 수정합니다. (스케쥴링 및 수동 실행만 동작)