### PR TITLE
[QP-6629] Insert 및 Update의 row에 존재하는 subquery에 대한 컬럼 및 테이블 정보 취득

### DIFF
--- a/Qsi.Debugger/MainWindow.axaml.cs
+++ b/Qsi.Debugger/MainWindow.axaml.cs
@@ -34,6 +34,7 @@ using Qsi.Debugger.Vendor.PrimarSql;
 using Qsi.Debugger.Vendor.Redshift;
 using Qsi.Debugger.Vendor.SqlServer;
 using Qsi.Debugger.Vendor.Trino;
+using Qsi.Engines.Explain;
 using Qsi.SqlServer.Common;
 using Qsi.Tree;
 
@@ -232,6 +233,7 @@ public class MainWindow : Window
             {
                 IQsiAnalysisResult[] results = await _vendor.Engine.Explain(script);
                 tables.AddRange(results.OfType<QsiTableResult>().Select(r => r.Table));
+                tables.AddRange(results.OfType<QsiExplainDataManipulationResult>().SelectMany(r => r.TablesInRows));
             }
 
             BuildQsiTableTree(tables);

--- a/Qsi/Analyzers/Action/Cache/DmlTableStructureCache.cs
+++ b/Qsi/Analyzers/Action/Cache/DmlTableStructureCache.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Qsi.Analyzers.Action.Models;
+using Qsi.Data;
+
+namespace Qsi.Analyzers.Action.Cache;
+
+public class DmlTableStructureCache : ITableStructureCache<DataManipulationTarget>
+{
+    private readonly Dictionary<DataManipulationTarget, List<QsiTableStructure>> _cache = new();
+
+    public void Add(DataManipulationTarget key, QsiTableStructure table)
+    {
+        if (_cache.TryGetValue(key, out List<QsiTableStructure> value))
+        {
+            value.Add(table);
+            return;
+        }
+
+        _cache[key] = new List<QsiTableStructure> { table };
+    }
+
+    public void AddRange(DataManipulationTarget key, IEnumerable<QsiTableStructure> tables)
+    {
+        if (_cache.TryGetValue(key, out List<QsiTableStructure> value))
+        {
+            value.AddRange(tables);
+            return;
+        }
+
+        _cache[key] = new List<QsiTableStructure>(tables);
+    }
+
+    public ICollection<QsiTableStructure> Get(DataManipulationTarget key)
+    {
+        return _cache[key];
+    }
+
+    public void Clear()
+    {
+        _cache.Clear();
+    }
+}

--- a/Qsi/Analyzers/Action/Cache/ITableStructureCache.cs
+++ b/Qsi/Analyzers/Action/Cache/ITableStructureCache.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Qsi.Data;
+
+namespace Qsi.Analyzers.Action.Cache;
+
+/// <summary>
+/// 사용된 서브쿼리를 분석한 Table Structure 리스트를 캐싱하는 인터페이스입니다.
+/// </summary>
+public interface ITableStructureCache<in T>
+{
+    /// <summary>
+    /// T에 해당하는 Table Structure를 추가합니다.
+    /// </summary>
+    /// <param name="key">캐시를 저장할 키 값입니다.</param>
+    /// <param name="table">캐싱할 테이블입니다.</param>
+    void Add(T key, QsiTableStructure table);
+
+    /// <summary>
+    /// T에 해당하는 Table Structure 목록을 추가합니다.
+    /// </summary>
+    /// <param name="key">캐시를 저장할 키 값입니다.</param>
+    /// <param name="tables">캐싱할 테이블 목록입니다.</param>
+    void AddRange(T key, IEnumerable<QsiTableStructure> tables);
+
+    /// <summary>
+    /// T에 해당하는 Table Structure 목록을 가져옵니다.
+    /// </summary>
+    /// <param name="key">목록을 식별할 수 있는 키 값입니다.</param>
+    /// <returns>Table Structure 목록입니다.</returns>
+    ICollection<QsiTableStructure> Get(T key);
+
+    /// <summary>
+    /// 캐시를 초기화합니다.
+    /// </summary>
+    void Clear();
+}

--- a/Qsi/Analyzers/Action/Context/TableDataInsertContext.cs
+++ b/Qsi/Analyzers/Action/Context/TableDataInsertContext.cs
@@ -1,4 +1,5 @@
-﻿using Qsi.Analyzers.Action.Models;
+﻿using Qsi.Analyzers.Action.Cache;
+using Qsi.Analyzers.Action.Models;
 using Qsi.Analyzers.Context;
 using Qsi.Data;
 
@@ -9,6 +10,8 @@ public sealed class TableDataInsertContext : TableDataContext
     public DataManipulationTarget[] Targets { get; set; }
 
     public ColumnTarget[] ColumnTargets { get; set; }
+
+    public DmlTableStructureCache TableStructureCache { get; } = new();
 
     public TableDataInsertContext(IAnalyzerContext context, QsiTableStructure table) : base(context, table)
     {

--- a/Qsi/Analyzers/Action/QsiActionAnalyzer.cs
+++ b/Qsi/Analyzers/Action/QsiActionAnalyzer.cs
@@ -948,10 +948,10 @@ public class QsiActionAnalyzer : QsiAnalyzerBase
         var affectedColumnMap = new bool[sourceTable.Columns.Count];
         ColumnTarget[] columnTargets;
 
-        var tablesInRows = new List<QsiTableStructure>[sourceTable.Columns.Count];
+        var tablesInRows = new IEnumerable<QsiTableStructure>[sourceTable.Columns.Count];
 
-        for (int i = 0; i < sourceTable.Columns.Count; ++i)
-            tablesInRows[i] = new List<QsiTableStructure>();
+        for (var i = 0; i < sourceTable.Columns.Count; ++i)
+            tablesInRows[i] = Enumerable.Empty<QsiTableStructure>();
 
         if (!ListUtility.IsNullOrEmpty(action.SetValues))
         {
@@ -964,7 +964,7 @@ public class QsiActionAnalyzer : QsiAnalyzerBase
                 values[targetIndex] = ResolveColumnValue(context, columnTarget.ValueNode);
                 affectedColumnMap[targetIndex] = true;
 
-                tablesInRows[targetIndex].AddRange(GetTables(columnTarget.ValueNode));
+                tablesInRows[targetIndex] = tablesInRows[targetIndex].Concat(GetTables(columnTarget.ValueNode));
             }
         }
         else if (action.Value != null)
@@ -977,7 +977,7 @@ public class QsiActionAnalyzer : QsiAnalyzerBase
             for (int i = 0; i < values.Length; i++)
             {
                 values[i] = ResolveColumnValue(context, action.Value.ColumnValues[i]);
-                tablesInRows[i].AddRange(GetTables(action.Value.ColumnValues[i]));
+                tablesInRows[i] = GetTables(action.Value.ColumnValues[i]);
             }
 
             affectedColumnMap.AsSpan().Fill(true);

--- a/Qsi/Data/Action/QsiDataManipulationResult.cs
+++ b/Qsi/Data/Action/QsiDataManipulationResult.cs
@@ -1,4 +1,6 @@
-﻿using Qsi.Analyzers;
+﻿using System;
+using System.Collections.Generic;
+using Qsi.Analyzers;
 
 namespace Qsi.Data;
 
@@ -17,6 +19,8 @@ public class QsiDataManipulationResult : IQsiAnalysisResult
     public QsiDataRowCollection UpdateAfterRows { get; set; }
 
     public QsiDataRowCollection DeleteRows { get; set; }
+
+    public ICollection<QsiTableStructure> TablesInRows { get; set; } = Array.Empty<QsiTableStructure>();
 
     public QsiSensitiveDataCollection SensitiveDataCollection { get; } = new();
 }

--- a/Qsi/Engines/Explain/Analyzers/ExplainActionAnalyzer.cs
+++ b/Qsi/Engines/Explain/Analyzers/ExplainActionAnalyzer.cs
@@ -73,7 +73,8 @@ internal sealed class ExplainActionAnalyzer : IQsiAnalyzer
         var explainResult = new QsiExplainDataManipulationResult(
             result.Table,
             result.AffectedColumns,
-            operations
+            operations,
+            result.TablesInRows
         );
 
         explainResult.SensitiveDataCollection.AddRange(result.SensitiveDataCollection);

--- a/Qsi/Engines/Explain/Results/QsiExplainDataManipulationResult.cs
+++ b/Qsi/Engines/Explain/Results/QsiExplainDataManipulationResult.cs
@@ -1,4 +1,6 @@
-﻿using Qsi.Analyzers;
+﻿using System;
+using System.Collections.Generic;
+using Qsi.Analyzers;
 using Qsi.Data;
 
 namespace Qsi.Engines.Explain;
@@ -13,10 +15,25 @@ public sealed class QsiExplainDataManipulationResult : IQsiAnalysisResult
 
     public QsiSensitiveDataCollection SensitiveDataCollection { get; } = new();
 
-    public QsiExplainDataManipulationResult(QsiTableStructure table, QsiTableColumn[] affectedColumns, QsiDataValueOperation[] operations)
+    public ICollection<QsiTableStructure> TablesInRows { get; }
+
+    public QsiExplainDataManipulationResult(
+        QsiTableStructure table,
+        QsiTableColumn[] affectedColumns,
+        QsiDataValueOperation[] operations)
+        : this(table, affectedColumns, operations, Array.Empty<QsiTableStructure>())
+    {
+    }
+
+    public QsiExplainDataManipulationResult(
+        QsiTableStructure table,
+        QsiTableColumn[] affectedColumns,
+        QsiDataValueOperation[] operations,
+        ICollection<QsiTableStructure> tablesInRows)
     {
         Table = table;
         AffectedColumns = affectedColumns;
         Operations = operations;
+        TablesInRows = tablesInRows;
     }
 }


### PR DESCRIPTION
# 개요
- Row에 서브쿼리가 포함될 경우, 서브쿼리 정보를 `QsiTableStructure`에 담아 `IAnalysisResult`에서 제공합니다.

# 변경사항
## 주요 변경사항
- `ITableStructureCache` 인터페이스를 통해, 키에 해당하는 `QsiTableStructure` 리스트를 반환합니다.
- `QsiDataManipulationResult` 및 `QsiExplainDataManipulationResult`에 `TablesInRows`를 추가합니다.
  - 해당 프로퍼티를 통해 Row에 존재하는 서브쿼리 정보를 전달하게 됩니다.
- `QsiActionAnalyzer`에서 Row 내에 서브쿼리가 존재할 경우, 이를 습득하여 `QsiTableStructure`로 전환하고 이를 결과로 제공합니다.
  - Insert 문의 경우, 모든 Row를 순회하며 서브쿼리를 해당 컨텍스트의 cache에 담습니다.
    - 이후 결과를 반환할 때 cache에 담긴 모든 테이블을 반환합니다.
  - Update 문의 경우, 역시 Row를 순회하며 서브쿼리를 임시 리스트에 저장 후 결과 반환 시 리스트의 테이블들을 반환합니다. 

## 기타 변경사항
- 추가: 디버거에서 `QsiExplainDanaManipulationResult`의 `TablesInRows` 프로퍼티에 존재하는 테이블들을 볼 수 있도록 기능을 추가했습니다.
- 수정: Expression 내에 존재하는 서브쿼리들을 리스트로 flatten하여 가져오는 CollectSubqueries 함수를 inner function에서 private 메서드로 변경했습니다.

# 스크린샷
<img width="2672" alt="image" src="https://github.com/chequer-io/qsi/assets/43464986/568c4e40-0d80-4670-a147-5769eeff35e1">

<img width="2672" alt="image" src="https://github.com/chequer-io/qsi/assets/43464986/738318a8-7f33-4d22-a8b5-f2eb76035e36">


# 이슈
QP-6629