### PR TITLE
QP-9047 Add SqlServerVariableSetActionNode (Select Variable Set statement)

### DIFF
--- a/Qsi.SqlServer/Diagnostics/SqlServerRawTreeVisitor.Core.cs
+++ b/Qsi.SqlServer/Diagnostics/SqlServerRawTreeVisitor.Core.cs
@@ -39,7 +39,7 @@ internal sealed partial class SqlServerRawTreeVisitor : TSqlFragmentVisitor
         visitor(fragment);
         _stack.Pop();
 
-        if (current.ChildrenCount == 0)
+        if (current.ChildrenCount == 0 && fragment.FragmentLength != -1)
         {
             var builder = new StringBuilder();
 

--- a/Qsi.SqlServer/SqlServerParser.cs
+++ b/Qsi.SqlServer/SqlServerParser.cs
@@ -156,6 +156,9 @@ public sealed class SqlServerParser : IQsiTreeParser, IVisitorContext
                 case ViewStatementBody viewStatementBody:
                     return _definitionVisitor.VisitViewStatementBody(viewStatementBody);
 
+                case SetVariableStatement setVariableStatement:
+                    return _actionVisitor.VisitSetVariableStatement(setVariableStatement);
+
                 default:
                     return _tableVisitor.Visit(statement);
             }

--- a/Qsi.SqlServer/Tree/SqlServerVariableSetActionNode.cs
+++ b/Qsi.SqlServer/Tree/SqlServerVariableSetActionNode.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Qsi.Tree;
+using Qsi.Utilities;
+
+namespace Qsi.SqlServer.Tree;
+
+public class SqlServerVariableSetActionNode : QsiVariableSetActionNode
+{
+    public QsiTreeNodeProperty<QsiTableNode> Source { get; }
+
+    public override IEnumerable<IQsiTreeNode> Children => TreeHelper.YieldChildren(base.Children, Source);
+
+    public SqlServerVariableSetActionNode()
+    {
+        Source = new QsiTreeNodeProperty<QsiTableNode>(this);
+    }
+}

--- a/Qsi.SqlServer/Tree/Visitors/TableVisitor.cs
+++ b/Qsi.SqlServer/Tree/Visitors/TableVisitor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.SqlServer.Management.SqlParser.SqlCodeDom;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 using Qsi.Data;
 using Qsi.SqlServer.Data;
@@ -31,6 +32,10 @@ internal sealed class TableVisitor : VisitorBase
     {
         switch (statementWithCtesAndXmlNamespaces)
         {
+            case SelectStatement { QueryExpression: QuerySpecification querySpecification } when
+                querySpecification.SelectElements.All(expr => expr is SelectSetVariable):
+                return ActionVisitor.VisitSelectVariableStatement(querySpecification);
+
             case SelectStatement selectStatement:
                 return VisitSelectStatement(selectStatement);
         }

--- a/Qsi.SqlServer/Tree/Visitors/VisitorBase.cs
+++ b/Qsi.SqlServer/Tree/Visitors/VisitorBase.cs
@@ -8,6 +8,8 @@ internal abstract class VisitorBase
 
     protected IdentifierVisitor IdentifierVisitor => _visitorContext.IdentifierVisitor;
 
+    protected ActionVisitor ActionVisitor => _visitorContext.ActionVisitor;
+
     private readonly IVisitorContext _visitorContext;
 
     protected VisitorBase(IVisitorContext visitorContext)


### PR DESCRIPTION
SQLServer의 SET 구문과 SELECT SET 구문에 대해 Node를 생성합니다.

``` sql
SELECT @var1 = 1;
SET @var1 = 1;
```

위의 두가지 형태의 변수 할당 구문을 지원합니다.

Issue: QP-9047