### PR TITLE
[QP-6629] Add condition when SourceColumn is null

### DIFF
--- a/Qsi/Analyzers/Action/QsiActionAnalyzer.cs
+++ b/Qsi/Analyzers/Action/QsiActionAnalyzer.cs
@@ -806,6 +806,7 @@ public class QsiActionAnalyzer : QsiAnalyzerBase
         foreach (var target in context.Targets)
         {
             IEnumerable<QsiTableStructure> tables = target.DataPivots
+                .Where(pivot => pivot.SourceColumn is not null)
                 .Select(expressionSelector)
                 .SelectMany(CollectSubqueries)
                 .Select(n =>


### PR DESCRIPTION
# 개요
- SourceColumn이 null일 때를 처리합니다.
  - `INSERT INTO actor(actor_id)`와 같이, 일부 컬럼을 대상으로 한 insert의 경우 SourceColumn이 null이 될 수 있습니다.