### PR TITLE
[QP-9760] Replace DatePart expression in Date functions

### DIFF
--- a/Qsi.SqlServer/Analyzers/SqlServerTableAnalyzer.cs
+++ b/Qsi.SqlServer/Analyzers/SqlServerTableAnalyzer.cs
@@ -23,6 +23,9 @@ public class SqlServerTableAnalyzer : QsiTableAnalyzer
         {
             case SqlServerPhyslocExpressionNode:
                 return Enumerable.Empty<QsiTableColumn>();
+            
+            case SqlServerDatePartExpressionNode:
+                return Enumerable.Empty<QsiTableColumn>();
         }
 
         return base.ResolveColumnsInExpression(context, expression);

--- a/Qsi.SqlServer/Tree/SqlServerDatePartExpressionNode.cs
+++ b/Qsi.SqlServer/Tree/SqlServerDatePartExpressionNode.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Linq;
+using Qsi.Tree;
+
+namespace Qsi.SqlServer.Tree;
+
+public class SqlServerDatePartExpressionNode : QsiExpressionNode
+{
+    public override IEnumerable<IQsiTreeNode> Children => Enumerable.Empty<IQsiTreeNode>();
+
+    public string DatePart { get; set; }
+}


### PR DESCRIPTION
DATE 기반 함수 중에서 첫번째 파라미터를 DATEPART로 사용하는 함수가 column 으로 인식되어서 Reference 오류가 발생하던 문제를 해결합니다.

대상 함수는 아래와 같습니다.

DATE_BUCKET
DATEADD
DATEDIFF
DATEDIFF_BIG
DATENAME
DATEPART
DATETRUNC

만약 대상 함수들을 사용했을때 첫번째 파라미터가 1 Level Column 으로 인식된 경우 SqlServerDatePartExpression으로 치환합니다.