### PR TITLE
[QP-9909] Microsoft.SqlServer.TransactSql.ScriptDom dll 직접 참조에서 Nuget 참조로 변경

### DIFF
--- a/Qsi.SqlServer/Qsi.SqlServer.csproj
+++ b/Qsi.SqlServer/Qsi.SqlServer.csproj
@@ -15,20 +15,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom, Version=15.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">
-        <HintPath>lib\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
-      </Reference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <_PackageFiles Include="lib\Microsoft.SqlServer.TransactSql.ScriptDom.dll">
-            <BuildAction>None</BuildAction>
-            <PackagePath>lib\net6.0</PackagePath>
-        </_PackageFiles>
-    </ItemGroup>
-
-    <ItemGroup>
       <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="160.22504.0" />
+      <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="161.9123.0" />
     </ItemGroup>
 
     <Import Project="..\Qsi.Shared\Qsi.Shared.projitems" Label="Shared" />


### PR DESCRIPTION
최초 SQLServer QSI 개발 시점에는 공식 Nuget이 없었기 때문에 dll을 직접 참조하여 사용하고 있었습니다.

하지만 이런 방식으로 참조할 경우 Qsi.SqlServer를 사용하는 프로젝트에서 Nuget으로 참조하여 사용하는 경우 버전 관련해서 문제가 발생할 수 있습니다.

따라서 이를 Nuget의 Microsoft.SqlServer.TransactSql.ScriptDom 패키지를 바라보도록 PackageReference로 변경합니다.

Issue: QP-9909